### PR TITLE
fix(authenticators/oidc): prevent random logout

### DIFF
--- a/addon/authenticators/oidc.js
+++ b/addon/authenticators/oidc.js
@@ -92,6 +92,16 @@ export default BaseAuthenticator.extend({
       this._timestampToDate(this._parseToken(access_token).exp) < new Date()
     ) {
       return await this._refresh(refresh_token);
+    } else {
+      // If the above expression returns false, the restore is not called again and the token is left to die.
+      // To prevent this, we schedule another restore when the token is expired.
+      later(
+        this,
+        async () => {
+          this.restore(sessionData);
+        },
+        this._timestampToDate(this._parseToken(access_token).exp) - new Date()
+      );
     }
 
     return sessionData;

--- a/addon/authenticators/oidc.js
+++ b/addon/authenticators/oidc.js
@@ -92,17 +92,17 @@ export default BaseAuthenticator.extend({
       this._timestampToDate(this._parseToken(access_token).exp) < new Date()
     ) {
       return await this._refresh(refresh_token);
-    } else {
-      // If the above expression returns false, the restore is not called again and the token is left to die.
-      // To prevent this, we schedule another restore when the token is expired.
-      later(
-        this,
-        async () => {
-          this.restore(sessionData);
-        },
-        this._timestampToDate(this._parseToken(access_token).exp) - new Date()
-      );
     }
+
+    // If the above expression returns false, the restore is not called again and the token is left to die.
+    // To prevent this, we schedule another restore when the token is expired.
+    later(
+      this,
+      () => {
+        this.restore(sessionData);
+      },
+      this._timestampToDate(this._parseToken(access_token).exp) - new Date()
+    );
 
     return sessionData;
   },


### PR DESCRIPTION
If a session is restored but the token is still valid, no refresh loop is started to prevent a
infinite token refresh loop on multiple tabs. This token is never checked again so we never start a
refresh loop even if the token is already exipred. This causes the next request to return a 401 and
invalidates the session.