### PR TITLE
Remove keycloak specific configuration option

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,9 +22,8 @@ env:
   matrix:
     # we recommend new addons test the current and previous LTS
     # as well as latest stable release (bonus points to beta/canary)
-    - EMBER_TRY_SCENARIO=ember-lts-2.12
-    - EMBER_TRY_SCENARIO=ember-lts-2.16
     - EMBER_TRY_SCENARIO=ember-lts-2.18
+    - EMBER_TRY_SCENARIO=ember-lts-3.4
     - EMBER_TRY_SCENARIO=ember-release
     - EMBER_TRY_SCENARIO=ember-beta
     - EMBER_TRY_SCENARIO=ember-canary

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,15 @@
+# Change Log
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/)
+and this project adheres to [Semantic Versioning](https://semver.org/).
+
+## [Unreleased]
+
+### Changed
+
+- Remove `realm` part as this is keycloak and not OIDC specific. In the case
+  of a keycloak implementation, the `realm` should be part of the `host`.
+  This change is not backwards compatible! Just remove the `realm` property
+  from your configuration and add it directly to the `host` property.

--- a/addon/authenticators/oidc.js
+++ b/addon/authenticators/oidc.js
@@ -6,16 +6,9 @@ import Configuration from "ember-simple-auth/configuration";
 import { assert } from "@ember/debug";
 import config from "ember-simple-auth-oidc/config";
 
-const {
-  host,
-  realm,
-  tokenEndpoint,
-  logoutEndpoint,
-  clientId,
-  refreshLeeway
-} = config;
+const { host, tokenEndpoint, logoutEndpoint, clientId, refreshLeeway } = config;
 
-const getUrl = endpoint => `${host}/realms/${realm}${endpoint}`;
+const getUrl = endpoint => `${host}${endpoint}`;
 
 export default BaseAuthenticator.extend({
   ajax: service(),

--- a/addon/authenticators/oidc.js
+++ b/addon/authenticators/oidc.js
@@ -30,7 +30,7 @@ export default BaseAuthenticator.extend({
    * @returns {Object} The parsed response data
    */
   async authenticate({ code }) {
-    let data = await this.ajax.post(getUrl(tokenEndpoint), {
+    let data = await this.get("ajax").post(getUrl(tokenEndpoint), {
       responseType: "application/json",
       contentType: "application/x-www-form-urlencoded",
       data: {
@@ -52,7 +52,7 @@ export default BaseAuthenticator.extend({
    * @return {Promise} The logout request
    */
   async invalidate({ refresh_token }) {
-    return await this.ajax.post(getUrl(logoutEndpoint), {
+    return await this.get("ajax").post(getUrl(logoutEndpoint), {
       responseType: "application/json",
       contentType: "application/x-www-form-urlencoded",
       data: {
@@ -106,7 +106,7 @@ export default BaseAuthenticator.extend({
    * @returns {Object} The parsed response data
    */
   async _refresh(refresh_token) {
-    let data = await this.ajax.post(getUrl(tokenEndpoint), {
+    let data = await this.get("ajax").post(getUrl(tokenEndpoint), {
       responseType: "application/json",
       contentType: "application/x-www-form-urlencoded",
       data: {

--- a/addon/authenticators/oidc.js
+++ b/addon/authenticators/oidc.js
@@ -153,7 +153,7 @@ export default BaseAuthenticator.extend({
    * @returns {Date} The date which results out of the timestamp
    */
   _timestampToDate(ts) {
-    return new Date(ts * 1000);
+    return new Date(ts);
   },
 
   /**

--- a/addon/config.js
+++ b/addon/config.js
@@ -4,7 +4,6 @@ export default Object.assign(
   {
     host: "http://localhost:4200",
     clientId: "client",
-    realm: "realm",
     authEndpoint: "/protocol/openid-connect/auth",
     tokenEndpoint: "/protocol/openid-connect/token",
     logoutEndpoint: "/protocol/openid-connect/logout",

--- a/addon/mixins/oidc-authentication-route-mixin.js
+++ b/addon/mixins/oidc-authentication-route-mixin.js
@@ -7,7 +7,7 @@ import config from "ember-simple-auth-oidc/config";
 import v4 from "uuid/v4";
 import { assert } from "@ember/debug";
 
-const { host, realm, clientId, authEndpoint } = config;
+const { host, clientId, authEndpoint } = config;
 
 export default Mixin.create(UnauthenticatedRouteMixin, {
   session: service(),
@@ -33,14 +33,14 @@ export default Mixin.create(UnauthenticatedRouteMixin, {
    *    client will try to authenticate with the given parameters.
    *
    * 2. The URL does not contain an authentication. In this case the client
-   *    will be redirected to the configured keycloak login mask, which will
+   *    will be redirected to the configured identity provider login mask, which will
    *    then redirect to this route after a successful login.
    *
    * @param {*} model The model of the route
    * @param {Ember.Transition} transition The current transition
    * @param {Object} transition.queryParams The query params of the transition
-   * @param {String} transition.queryParams.code The authentication code given by keycloak
-   * @param {String} transition.queryParams.state The state given by keycloak
+   * @param {String} transition.queryParams.code The authentication code given by the identity provider
+   * @param {String} transition.queryParams.state The state given by the identity provider
    */
   async afterModel(
     _,
@@ -56,7 +56,7 @@ export default Mixin.create(UnauthenticatedRouteMixin, {
   },
 
   /**
-   * Authenticate with the authentication code given by keycloak in the redirect.
+   * Authenticate with the authentication code given by the identity provider in the redirect.
    *
    * This will check if the passed state equals the state in the application to
    * prevent from CSRF attacks.
@@ -68,8 +68,8 @@ export default Mixin.create(UnauthenticatedRouteMixin, {
    * will apply and redirect to the entry point of the authenticated part of
    * the application.
    *
-   * @param {String} code The authentication code passed by keycloak
-   * @param {String} state The state (uuid4) passed by keycloak
+   * @param {String} code The authentication code passed by the identity provider
+   * @param {String} state The state (uuid4) passed by the identity provider
    */
   async _handleCallbackRequest(code, state) {
     if (state !== this.get("session.data.state")) {
@@ -94,10 +94,10 @@ export default Mixin.create(UnauthenticatedRouteMixin, {
   },
 
   /**
-   * Redirect the client to the configured keycloak to login.
+   * Redirect the client to the configured identity provider login.
    *
    * This will also generate a uuid4 state which the application stores to the
-   * local storage. When authenticating, the state passed by keycloak needs to
+   * local storage. When authenticating, the state passed by the identity provider needs to
    * match this state, otherwise the authentication will fail to prevent from
    * CSRF attacks.
    */
@@ -117,7 +117,7 @@ export default Mixin.create(UnauthenticatedRouteMixin, {
     }
 
     this._redirectToUrl(
-      `${host}/realms/${realm}${authEndpoint}?` +
+      `${host}${authEndpoint}?` +
         `client_id=${clientId}&` +
         `redirect_uri=${this.redirectUri}&` +
         `response_type=code&` +

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -11,26 +11,18 @@ module.exports = function() {
     return {
       scenarios: [
         {
-          name: "ember-lts-2.12",
-          npm: {
-            devDependencies: {
-              "ember-source": "~2.12.0"
-            }
-          }
-        },
-        {
-          name: "ember-lts-2.16",
-          npm: {
-            devDependencies: {
-              "ember-source": "~2.16.0"
-            }
-          }
-        },
-        {
           name: "ember-lts-2.18",
           npm: {
             devDependencies: {
               "ember-source": "~2.18.0"
+            }
+          }
+        },
+        {
+          name: "ember-lts-3.4",
+          npm: {
+            devDependencies: {
+              "ember-source": "~3.4.0"
             }
           }
         },

--- a/tests/dummy/config/environment.js
+++ b/tests/dummy/config/environment.js
@@ -8,7 +8,7 @@ module.exports = function(environment) {
     locationType: "auto",
 
     "ember-simple-auth-oidc": {
-      realm: "test-realm",
+      host: "http://localhost:4200/realms/test-realm",
       clientId: "test-client"
     },
 

--- a/tests/dummy/mirage/config.js
+++ b/tests/dummy/mirage/config.js
@@ -1,5 +1,5 @@
 export default function() {
-  this.urlPrefix = "";
+  this.urlPrefix = "http://localhost:4200";
   this.namespace = "";
   this.timing = 0;
 

--- a/tests/unit/authenticators/oidc-test.js
+++ b/tests/unit/authenticators/oidc-test.js
@@ -2,6 +2,15 @@ import { module, test } from "qunit";
 import { setupTest } from "ember-qunit";
 import setupMirage from "ember-cli-mirage/test-support/setup-mirage";
 
+const getTokenBody = expired => {
+  const time = expired ? -30 : 120;
+  return btoa(
+    JSON.stringify({
+      exp: Date.now() + time
+    })
+  );
+};
+
 module("Unit | Authenticator | OIDC", function(hooks) {
   setupTest(hooks);
   setupMirage(hooks);
@@ -34,8 +43,9 @@ module("Unit | Authenticator | OIDC", function(hooks) {
     };
 
     let data = await subject.restore({
-      access_token: "a.b.c",
-      refresh_token: "x.y.z"
+      access_token: `access.${getTokenBody(true)}.token`,
+      refresh_token: `refresh.${getTokenBody(false)}.token`,
+      data: { exp: Date.now() - 30 }
     });
 
     assert.ok(data.access_token, "Returns an access token");
@@ -94,11 +104,11 @@ module("Unit | Authenticator | OIDC", function(hooks) {
 
     let subject = this.owner.lookup("authenticator:oidc");
 
-    let timestamp = new Date().getTime() / 1000;
+    let timestamp = Date.now();
 
     assert.equal(
       subject._timestampToDate(timestamp).toString(),
-      new Date(timestamp * 1000).toString(),
+      new Date(timestamp).toString(),
       "Datetime is the correct representation of the timestamp"
     );
   });


### PR DESCRIPTION
Remove the keycloak specific `realm` config option since this is not a OIDC standard. The `realm` option should be part of the `host` configuration.

Further fixed the existing tests and started a change log.