### PR TITLE
Add `scope` and access `userinfo` endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,8 +13,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   of a keycloak implementation, the `realm` should be part of the `host`.
   This change is not backwards compatible! Just remove the `realm` property
   from your configuration and add it directly to the `host` property.
-- Add config option `userinfoEndpoint`, `scope` and `expiresIn`
-- Scope is required by OIDC and is now always delivered to the auth endpoint
+- Add required config option `scope` as scope is required by OIDC standard and
+  is now always delivered to the auth endpoint
+- Add required config option `userinfoEndpoint`
+- Add optional config option `expiresIn`
+- Remove default values for all endpoint config options. They need to be set
+  specific in the project config file.
 - No longer parse the `access_token` for user information instead request the
   user information from the userinfo endpoint. Make sure the userinfo endpoint
   is available and correctly configured!

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,3 +13,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   of a keycloak implementation, the `realm` should be part of the `host`.
   This change is not backwards compatible! Just remove the `realm` property
   from your configuration and add it directly to the `host` property.
+- Add config option `userinfoEndpoint`, `scope` and `expiresIn`
+- Scope is required by OIDC and is now always delivered to the auth endpoint
+- No longer parse the `access_token` for user information instead request the
+  user information from the userinfo endpoint. Make sure the userinfo endpoint
+  is available and correctly configured!
+- Use the `expires_in` time from the token endpoint if available otherwise
+  fallback to the config `expiresIn` value.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - Add required config option `userinfoEndpoint`
 - Add optional config option `expiresIn`
 - Remove default values for all endpoint config options. They need to be set
-  specific in the project config file.
+  specifically in the project config file.
 - No longer parse the `access_token` for user information instead request the
   user information from the userinfo endpoint. Make sure the userinfo endpoint
   is available and correctly configured!

--- a/addon/authenticators/oidc.js
+++ b/addon/authenticators/oidc.js
@@ -39,6 +39,12 @@ export default BaseAuthenticator.extend({
    * @returns {Object} The parsed response data
    */
   async authenticate({ code }) {
+    if (!tokenEndpoint || !logoutEndpoint || !userinfoEndpoint) {
+      throw new Error(
+        "Please define all OIDC endpoints (auth, token, logout, userinfo)"
+      );
+    }
+
     let data = await this.get("ajax").post(getUrl(tokenEndpoint), {
       responseType: "application/json",
       contentType: "application/x-www-form-urlencoded",

--- a/addon/authenticators/oidc.js
+++ b/addon/authenticators/oidc.js
@@ -6,7 +6,16 @@ import Configuration from "ember-simple-auth/configuration";
 import { assert } from "@ember/debug";
 import config from "ember-simple-auth-oidc/config";
 
-const { host, tokenEndpoint, logoutEndpoint, clientId, refreshLeeway } = config;
+const {
+  host,
+  tokenEndpoint,
+  logoutEndpoint,
+  userinfoEndpoint,
+  clientId,
+  refreshLeeway,
+  authPrefix,
+  expiresIn
+} = config;
 
 const getUrl = endpoint => `${host}${endpoint}`;
 
@@ -80,23 +89,7 @@ export default BaseAuthenticator.extend({
       assert("Token is missing");
     }
 
-    // Prevent a token refresh if the token is not expired.
-    if (
-      this._timestampToDate(this._parseToken(access_token).exp) < new Date()
-    ) {
-      return await this._refresh(refresh_token);
-    }
-
-    // If the above expression returns false, the restore is not called again and the token is left to die.
-    // To prevent this, we schedule another restore when the token is expired.
-    later(
-      this,
-      async () =>
-        this.trigger("sessionDataUpdated", await this.restore(sessionData)),
-      this._timestampToDate(this._parseToken(access_token).exp) - new Date()
-    );
-
-    return sessionData;
+    return await this._refresh(refresh_token);
   },
 
   /**
@@ -125,40 +118,33 @@ export default BaseAuthenticator.extend({
    *
    * This refresh needs to happen before the access token actually expires.
    *
-   * @param {*} datetime The datetime at which the access token expires
-   * @param {*} token The refresh token
+   * @param {Number} milliseconds Millilseconds before the access token expires
+   * @param {String} token The refresh token
    */
-  _scheduleRefresh(datetime, token) {
+  _scheduleRefresh(milliseconds, token) {
     later(
       this,
       async token => {
         this.trigger("sessionDataUpdated", await this._refresh(token));
       },
       token,
-      datetime - refreshLeeway - new Date()
+      milliseconds - refreshLeeway
     );
   },
 
   /**
-   * Convert a unix timestamp to a date object
+   * Request user information from the openid userinfo endpoint
    *
-   * @param {Number} exp The unix timestamp
-   * @returns {Date} The date which results out of the timestamp
+   * @param {String} accessToken The raw access token
+   * @returns {Object} Object containing the user information
    */
-  _timestampToDate(ts) {
-    return new Date(ts);
-  },
+  async _getUserinfo(accessToken) {
+    const userinfo = await this.get("ajax").request(getUrl(userinfoEndpoint), {
+      headers: { Authorization: `${authPrefix} ${accessToken}` },
+      responseType: "application/json"
+    });
 
-  /**
-   * Parse the body of a bearer token
-   *
-   * @param {String} token The raw bearer token
-   * @returns {Object} The parsed token data
-   */
-  _parseToken(token) {
-    let [, body] = token.split(".");
-
-    return JSON.parse(decodeURIComponent(escape(atob(body))));
+    return userinfo;
   },
 
   /**
@@ -168,13 +154,16 @@ export default BaseAuthenticator.extend({
    * @param {Object} response The raw response data
    * @param {String} response.access_token The raw access token
    * @param {String} response.refresh_token The raw refresh token
+   * @param {Number} response.expires_in Seconds until access_token expires
    * @returns {Object} The authentication data
    */
-  _handleAuthResponse({ access_token, refresh_token }) {
-    let data = this._parseToken(access_token);
+  async _handleAuthResponse({ access_token, refresh_token, expires_in }) {
+    const userinfo = await this._getUserinfo(access_token);
 
-    this._scheduleRefresh(this._timestampToDate(data.exp), refresh_token);
+    const expireTime = expires_in ? expires_in * 1000 : expiresIn;
 
-    return { access_token, refresh_token, data };
+    this._scheduleRefresh(expireTime, refresh_token);
+
+    return { access_token, refresh_token, userinfo };
   }
 });

--- a/addon/config.js
+++ b/addon/config.js
@@ -7,6 +7,10 @@ export default Object.assign(
     authEndpoint: "/protocol/openid-connect/auth",
     tokenEndpoint: "/protocol/openid-connect/token",
     logoutEndpoint: "/protocol/openid-connect/logout",
+    userinfoEndpoint: "/protocol/openid-connect/userinfo",
+    scope: "openid",
+    // expiresIn is the fallback expire time if none is given
+    expiresIn: 3600,
     refreshLeeway: 1000 * 30,
     tokenPropertyName: "access_token",
     authHeaderName: "Authorization",

--- a/addon/config.js
+++ b/addon/config.js
@@ -4,10 +4,10 @@ export default Object.assign(
   {
     host: "http://localhost:4200",
     clientId: "client",
-    authEndpoint: "/protocol/openid-connect/auth",
-    tokenEndpoint: "/protocol/openid-connect/token",
-    logoutEndpoint: "/protocol/openid-connect/logout",
-    userinfoEndpoint: "/protocol/openid-connect/userinfo",
+    authEndpoint: null,
+    tokenEndpoint: null,
+    logoutEndpoint: null,
+    userinfoEndpoint: null,
     scope: "openid",
     // expiresIn is the fallback expire time if none is given
     expiresIn: 3600 * 1000,

--- a/addon/config.js
+++ b/addon/config.js
@@ -10,7 +10,7 @@ export default Object.assign(
     userinfoEndpoint: "/protocol/openid-connect/userinfo",
     scope: "openid",
     // expiresIn is the fallback expire time if none is given
-    expiresIn: 3600,
+    expiresIn: 3600 * 1000,
     refreshLeeway: 1000 * 30,
     tokenPropertyName: "access_token",
     authHeaderName: "Authorization",

--- a/addon/mixins/oidc-authentication-route-mixin.js
+++ b/addon/mixins/oidc-authentication-route-mixin.js
@@ -48,6 +48,12 @@ export default Mixin.create(UnauthenticatedRouteMixin, {
       queryParams: { code, state }
     }
   ) {
+    if (!authEndpoint) {
+      throw new Error(
+        "Please define all OIDC endpoints (auth, token, logout, userinfo)"
+      );
+    }
+
     if (code) {
       return await this._handleCallbackRequest(code, state);
     }

--- a/addon/mixins/oidc-authentication-route-mixin.js
+++ b/addon/mixins/oidc-authentication-route-mixin.js
@@ -78,18 +78,14 @@ export default Mixin.create(UnauthenticatedRouteMixin, {
 
     this.session.set("data.state", undefined);
 
-    try {
-      await this.session.authenticate("authenticator:oidc", {
-        code
-      });
+    await this.session.authenticate("authenticator:oidc", {
+      code
+    });
 
-      let next = this.session.get("data.next");
+    let next = this.session.get("data.next");
 
-      if (next) {
-        this.replaceWith(next);
-      }
-    } catch (e) {
-      assert("Authentication failed");
+    if (next) {
+      this.replaceWith(next);
     }
   },
 

--- a/addon/mixins/oidc-authentication-route-mixin.js
+++ b/addon/mixins/oidc-authentication-route-mixin.js
@@ -7,7 +7,7 @@ import config from "ember-simple-auth-oidc/config";
 import v4 from "uuid/v4";
 import { assert } from "@ember/debug";
 
-const { host, clientId, authEndpoint } = config;
+const { host, clientId, authEndpoint, scope } = config;
 
 export default Mixin.create(UnauthenticatedRouteMixin, {
   session: service(),
@@ -121,7 +121,8 @@ export default Mixin.create(UnauthenticatedRouteMixin, {
         `client_id=${clientId}&` +
         `redirect_uri=${this.redirectUri}&` +
         `response_type=code&` +
-        `state=${state}`
+        `state=${state}&` +
+        `scope=${scope}`
     );
   }
 });

--- a/tests/dummy/config/environment.js
+++ b/tests/dummy/config/environment.js
@@ -9,7 +9,11 @@ module.exports = function(environment) {
 
     "ember-simple-auth-oidc": {
       host: "http://localhost:4200/realms/test-realm",
-      clientId: "test-client"
+      clientId: "test-client",
+      authEndpoint: "/protocol/openid-connect/auth",
+      tokenEndpoint: "/protocol/openid-connect/token",
+      logoutEndpoint: "/protocol/openid-connect/logout",
+      userinfoEndpoint: "/protocol/openid-connect/userinfo"
     },
 
     EmberENV: {

--- a/tests/dummy/mirage/config.js
+++ b/tests/dummy/mirage/config.js
@@ -4,15 +4,9 @@ export default function() {
   this.timing = 0;
 
   this.post("/realms/test-realm/protocol/openid-connect/token", function() {
-    let tokenBody = btoa(
-      JSON.stringify({
-        exp: Math.round(new Date().getTime() + 30 * 60)
-      })
-    );
-
     return {
-      access_token: `access.${tokenBody}.token`,
-      refresh_token: `refresh.${tokenBody}.token`
+      access_token: "access.token",
+      refresh_token: "refresh.token"
     };
   });
 

--- a/tests/dummy/mirage/config.js
+++ b/tests/dummy/mirage/config.js
@@ -6,7 +6,7 @@ export default function() {
   this.post("/realms/test-realm/protocol/openid-connect/token", function() {
     let tokenBody = btoa(
       JSON.stringify({
-        exp: Math.round(new Date().getTime() + (30 * 60 * 1000) / 1000)
+        exp: Math.round(new Date().getTime() + 30 * 60)
       })
     );
 
@@ -21,4 +21,8 @@ export default function() {
     () => null,
     200
   );
+
+  this.get("/realms/test-realm/protocol/openid-connect/userinfo", function() {
+    return { sub: 1 };
+  });
 }

--- a/tests/unit/authenticators/oidc-test.js
+++ b/tests/unit/authenticators/oidc-test.js
@@ -29,7 +29,7 @@ module("Unit | Authenticator | OIDC", function(hooks) {
 
     assert.ok(data.access_token, "Returns an access token");
     assert.ok(data.refresh_token, "Returns a refresh token");
-    assert.ok(data.data.exp, "Parses the access token correctly");
+    assert.ok(data.userinfo, "Returns the user info");
   });
 
   test("it can restore a session", async function(assert) {
@@ -44,13 +44,12 @@ module("Unit | Authenticator | OIDC", function(hooks) {
 
     let data = await subject.restore({
       access_token: `access.${getTokenBody(true)}.token`,
-      refresh_token: `refresh.${getTokenBody(false)}.token`,
-      data: { exp: Date.now() - 30 }
+      refresh_token: `refresh.${getTokenBody(false)}.token`
     });
 
     assert.ok(data.access_token, "Returns an access token");
     assert.ok(data.refresh_token, "Returns a refresh token");
-    assert.ok(data.data.exp, "Parses the access token correctly");
+    assert.ok(data.userinfo, "Returns the user info");
   });
 
   test("it can invalidate a session", async function(assert) {
@@ -84,7 +83,7 @@ module("Unit | Authenticator | OIDC", function(hooks) {
 
     assert.ok(data.access_token, "Returns an access token");
     assert.ok(data.refresh_token, "Returns a refresh token");
-    assert.ok(data.data.exp, "Parses the access token correctly");
+    assert.ok(data.userinfo, "Returns the user info");
   });
 
   test("it can schedule a refresh", async function(assert) {
@@ -97,19 +96,5 @@ module("Unit | Authenticator | OIDC", function(hooks) {
     };
 
     subject._scheduleRefresh(new Date() + 30, "testtoken");
-  });
-
-  test("it can convert a unix timestamp to a date", async function(assert) {
-    assert.expect(1);
-
-    let subject = this.owner.lookup("authenticator:oidc");
-
-    let timestamp = Date.now();
-
-    assert.equal(
-      subject._timestampToDate(timestamp).toString(),
-      new Date(timestamp).toString(),
-      "Datetime is the correct representation of the timestamp"
-    );
   });
 });

--- a/tests/unit/mixins/oidc-authentication-route-mixin-test.js
+++ b/tests/unit/mixins/oidc-authentication-route-mixin-test.js
@@ -80,12 +80,11 @@ module("Unit | Mixin | oidc-authentication-route-mixin", function(hooks) {
     };
 
     // fails because of the error in authenticate
-    subject
-      .afterModel(null, {
+    assert.rejects(
+      subject.afterModel(null, {
         queryParams: { code: "sometestcode", state: "state2" }
-      })
-      .catch(e => {
-        assert.ok(/Authentication failed/.test(e.message));
-      });
+      }),
+      Error
+    );
   });
 });


### PR DESCRIPTION
Add the `scope` parameter to the authentication request as this is required by OIDC. Also get the user information from the `userinfo` endpoint and not by parsing the `access_token`.