### PR TITLE
Implement invalidate with end-session according to the OIDC specs

### DIFF
--- a/addon/authenticators/oidc.js
+++ b/addon/authenticators/oidc.js
@@ -2,6 +2,7 @@ import BaseAuthenticator from "ember-simple-auth/authenticators/base";
 import { computed } from "@ember/object";
 import { later } from "@ember/runloop";
 import { inject as service } from "@ember/service";
+import RSVP from "rsvp";
 import Configuration from "ember-simple-auth/configuration";
 import { assert } from "@ember/debug";
 import config from "ember-simple-auth-oidc/config";
@@ -64,11 +65,7 @@ export default BaseAuthenticator.extend({
    * @return {Promise} The invalidate promise
    */
   async invalidate() {
-    // eslint-disable-next-line no-unused-vars
-    return new Promise(function(resolve, reject) {
-      resolve(true);
-      // We never reject here
-    });
+    return RSVP.resolve(true);
   },
 
   /**

--- a/addon/authenticators/oidc.js
+++ b/addon/authenticators/oidc.js
@@ -9,7 +9,6 @@ import config from "ember-simple-auth-oidc/config";
 const {
   host,
   tokenEndpoint,
-  logoutEndpoint,
   userinfoEndpoint,
   clientId,
   refreshLeeway,
@@ -39,9 +38,9 @@ export default BaseAuthenticator.extend({
    * @returns {Object} The parsed response data
    */
   async authenticate({ code }) {
-    if (!tokenEndpoint || !logoutEndpoint || !userinfoEndpoint) {
+    if (!tokenEndpoint || !userinfoEndpoint) {
       throw new Error(
-        "Please define all OIDC endpoints (auth, token, logout, userinfo)"
+        "Please define all OIDC endpoints (auth, token, userinfo)"
       );
     }
 
@@ -66,16 +65,7 @@ export default BaseAuthenticator.extend({
    * @param {String} data.refresh_token The refresh token
    * @return {Promise} The logout request
    */
-  async invalidate({ refresh_token }) {
-    return await this.get("ajax").post(getUrl(logoutEndpoint), {
-      responseType: "application/json",
-      contentType: "application/x-www-form-urlencoded",
-      data: {
-        refresh_token,
-        client_id: clientId
-      }
-    });
-  },
+  async invalidate() {},
 
   /**
    * Restore the session after a page refresh. This will check if an access

--- a/addon/authenticators/oidc.js
+++ b/addon/authenticators/oidc.js
@@ -153,13 +153,18 @@ export default BaseAuthenticator.extend({
    * @param {Number} response.expires_in Seconds until access_token expires
    * @returns {Object} The authentication data
    */
-  async _handleAuthResponse({ access_token, refresh_token, expires_in }) {
+  async _handleAuthResponse({
+    access_token,
+    refresh_token,
+    expires_in,
+    id_token
+  }) {
     const userinfo = await this._getUserinfo(access_token);
 
     const expireTime = expires_in ? expires_in * 1000 : expiresIn;
 
     this._scheduleRefresh(expireTime, refresh_token);
 
-    return { access_token, refresh_token, userinfo };
+    return { access_token, refresh_token, userinfo, id_token };
   }
 });

--- a/addon/authenticators/oidc.js
+++ b/addon/authenticators/oidc.js
@@ -61,11 +61,15 @@ export default BaseAuthenticator.extend({
   /**
    * Invalidate the current session with the refresh token
    *
-   * @param {Object} data The authenticated data
-   * @param {String} data.refresh_token The refresh token
-   * @return {Promise} The logout request
+   * @return {Promise} The invalidate promise
    */
-  async invalidate() {},
+  async invalidate() {
+    // eslint-disable-next-line no-unused-vars
+    return new Promise(function(resolve, reject) {
+      resolve(true);
+      // We never reject here
+    });
+  },
 
   /**
    * Restore the session after a page refresh. This will check if an access

--- a/addon/config.js
+++ b/addon/config.js
@@ -7,7 +7,7 @@ export default Object.assign(
     authEndpoint: null,
     tokenEndpoint: null,
     endSessionEndpoint: null,
-    logoutRoute: "/logout",
+    afterLogoutUri: null,
     userinfoEndpoint: null,
     scope: "openid",
     // expiresIn is the fallback expire time if none is given

--- a/addon/config.js
+++ b/addon/config.js
@@ -6,7 +6,8 @@ export default Object.assign(
     clientId: "client",
     authEndpoint: null,
     tokenEndpoint: null,
-    logoutEndpoint: null,
+    endSessionEndpoint: null,
+    logoutRoute: "/logout",
     userinfoEndpoint: null,
     scope: "openid",
     // expiresIn is the fallback expire time if none is given

--- a/addon/mixins/oidc-application-route-mixin.js
+++ b/addon/mixins/oidc-application-route-mixin.js
@@ -1,0 +1,15 @@
+import ApplicationRouteMixin from "ember-simple-auth/mixins/application-route-mixin";
+import Mixin from "@ember/object/mixin";
+
+export default Mixin.create(ApplicationRouteMixin, {
+  sessionInvalidated() {
+    /**
+     * Overwrite the standard behavior of the
+     * sessionInvalidated event, which is redirecting
+     * to the rootUrl of the app. Since the OIDC addon
+     * redirects to the end-session endpoint after
+     * invalidating, this event should do nothing
+     * (or at least no redirecting!).
+     */
+  }
+});

--- a/addon/mixins/oidc-authentication-route-mixin.js
+++ b/addon/mixins/oidc-authentication-route-mixin.js
@@ -87,12 +87,6 @@ export default Mixin.create(UnauthenticatedRouteMixin, {
     await this.session.authenticate("authenticator:oidc", {
       code
     });
-
-    let next = this.session.get("data.next");
-
-    if (next) {
-      this.replaceWith(next);
-    }
   },
 
   /**
@@ -107,16 +101,6 @@ export default Mixin.create(UnauthenticatedRouteMixin, {
     let state = v4();
 
     this.session.set("data.state", state);
-
-    let attemptedTransition = this.get("session.attemptedTransition");
-
-    if (attemptedTransition) {
-      let {
-        intent: { url }
-      } = attemptedTransition;
-
-      this.session.set("data.next", url);
-    }
 
     this._redirectToUrl(
       `${host}${authEndpoint}?` +

--- a/addon/mixins/oidc-end-session-route-mixin.js
+++ b/addon/mixins/oidc-end-session-route-mixin.js
@@ -1,11 +1,13 @@
 import Mixin from "@ember/object/mixin";
-import AuthenticatedRouteMixin from "ember-simple-auth/mixins/authenticated-route-mixin";
+import { inject as service } from "@ember/service";
 import config from "ember-simple-auth-oidc/config";
 import v4 from "uuid/v4";
 
 const { host, endSessionEndpoint, logoutRoute } = config;
 
-export default Mixin.create(AuthenticatedRouteMixin, {
+export default Mixin.create({
+  session: service(),
+
   async afterModel(
     _,
     {

--- a/addon/mixins/oidc-end-session-route-mixin.js
+++ b/addon/mixins/oidc-end-session-route-mixin.js
@@ -2,7 +2,7 @@ import Mixin from "@ember/object/mixin";
 import { inject as service } from "@ember/service";
 import config from "ember-simple-auth-oidc/config";
 
-const { host, endSessionEndpoint, logoutRoute } = config;
+const { host, endSessionEndpoint, afterLogoutUri } = config;
 
 export default Mixin.create({
   session: service(),
@@ -17,15 +17,29 @@ export default Mixin.create({
   },
 
   _handleRedirect() {
-    const redirectUri = `${location.protocol}//${location.host}${logoutRoute}`;
+    const params = [];
+
+    if (afterLogoutUri) {
+      const redirectUri =
+        afterLogoutUri.indexOf("http") === 0
+          ? afterLogoutUri
+          : `${location.protocol}//${location.host}${afterLogoutUri}`;
+
+      params.push(`post_logout_redirect_uri=${redirectUri}`);
+    }
+
     const idToken = this.session.get("data.authenticated.id_token");
+    if (idToken) {
+      params.push(`id_token_hint=${idToken}`);
+    }
 
     this.session.invalidate();
 
-    location.replace(
-      `${host}${endSessionEndpoint}?` +
-        `id_token_hint=${idToken}&` +
-        `post_logout_redirect_uri=${redirectUri}`
-    );
+    let endSessionUri = `${host}${endSessionEndpoint}`;
+    if (params.length > 0) {
+      endSessionUri = `${endSessionUri}?${params.join("&")}`;
+    }
+
+    location.replace(endSessionUri);
   }
 });

--- a/addon/mixins/oidc-end-session-route-mixin.js
+++ b/addon/mixins/oidc-end-session-route-mixin.js
@@ -18,7 +18,11 @@ export default Mixin.create({
       this.session.invalidate();
     }
 
-    this._handleRedirect();
+    if (state) {
+      return this._handleCallback(state);
+    }
+
+    return this._handleRedirect();
   },
 
   _handleRedirect() {
@@ -35,5 +39,15 @@ export default Mixin.create({
         `post_logout_redirect_uri=${redirectUri}&` +
         `state=${state}`
     );
+  },
+
+  _handleCallback(state) {
+    if (state !== this.session.get("data.state")) {
+      throw new Error("End session state did not match");
+    }
+
+    this.session.set("data.state", undefined);
+
+    this.session.invalidate();
   }
 });

--- a/addon/mixins/oidc-end-session-route-mixin.js
+++ b/addon/mixins/oidc-end-session-route-mixin.js
@@ -40,6 +40,10 @@ export default Mixin.create({
       endSessionUri = `${endSessionUri}?${params.join("&")}`;
     }
 
-    location.replace(endSessionUri);
+    this._redirectToUrl(endSessionUri);
+  },
+
+  _redirectToUrl(url) {
+    location.replace(url);
   }
 });

--- a/addon/mixins/oidc-end-session-route-mixin.js
+++ b/addon/mixins/oidc-end-session-route-mixin.js
@@ -1,35 +1,22 @@
 import Mixin from "@ember/object/mixin";
 import { inject as service } from "@ember/service";
 import config from "ember-simple-auth-oidc/config";
-import v4 from "uuid/v4";
 
 const { host, endSessionEndpoint, logoutRoute } = config;
 
 export default Mixin.create({
   session: service(),
 
-  async afterModel(
-    _,
-    {
-      queryParams: { state }
-    }
-  ) {
+  // eslint-disable-next-line no-unused-vars
+  afterModel(model) {
     if (!endSessionEndpoint) {
-      this.session.invalidate();
-    }
-
-    if (state) {
-      return this._handleCallback(state);
+      return this.session.invalidate();
     }
 
     return this._handleRedirect();
   },
 
   _handleRedirect() {
-    const state = v4();
-
-    this.session.set("data.state", state);
-
     const redirectUri = `${location.protocol}//${location.host}${logoutRoute}`;
     const idToken = this.session.get("data.authenticated.id_token");
 
@@ -38,16 +25,7 @@ export default Mixin.create({
     location.replace(
       `${host}${endSessionEndpoint}?` +
         `id_token_hint=${idToken}&` +
-        `post_logout_redirect_uri=${redirectUri}&` +
-        `state=${state}`
+        `post_logout_redirect_uri=${redirectUri}`
     );
-  },
-
-  _handleCallback(state) {
-    if (state !== this.session.get("data.state")) {
-      throw new Error("End session state did not match");
-    }
-
-    this.session.set("data.state", undefined);
   }
 });

--- a/addon/mixins/oidc-end-session-route-mixin.js
+++ b/addon/mixins/oidc-end-session-route-mixin.js
@@ -1,11 +1,11 @@
 import Mixin from "@ember/object/mixin";
-import UnauthenticatedRouteMixin from "ember-simple-auth/mixins/unauthenticated-route-mixin";
+import AuthenticatedRouteMixin from "ember-simple-auth/mixins/authenticated-route-mixin";
 import config from "ember-simple-auth-oidc/config";
 import v4 from "uuid/v4";
 
 const { host, endSessionEndpoint, logoutRoute } = config;
 
-export default Mixin.create(UnauthenticatedRouteMixin, {
+export default Mixin.create(AuthenticatedRouteMixin, {
   async afterModel(
     _,
     {

--- a/addon/mixins/oidc-end-session-route-mixin.js
+++ b/addon/mixins/oidc-end-session-route-mixin.js
@@ -25,10 +25,12 @@ export default Mixin.create(AuthenticatedRouteMixin, {
     this.session.set("data.state", state);
 
     const redirectUri = `${location.protocol}//${location.host}${logoutRoute}`;
+    const idToken = this.session.get("data.authenticated.id_token");
 
     location.replace(
       `${host}${endSessionEndpoint}?` +
-        `post_logout_redirect_uri=${redirectUri}` +
+        `id_token_hint=${idToken}&` +
+        `post_logout_redirect_uri=${redirectUri}&` +
         `state=${state}`
     );
   }

--- a/addon/mixins/oidc-end-session-route-mixin.js
+++ b/addon/mixins/oidc-end-session-route-mixin.js
@@ -1,0 +1,35 @@
+import Mixin from "@ember/object/mixin";
+import UnauthenticatedRouteMixin from "ember-simple-auth/mixins/unauthenticated-route-mixin";
+import config from "ember-simple-auth-oidc/config";
+import v4 from "uuid/v4";
+
+const { host, endSessionEndpoint, logoutRoute } = config;
+
+export default Mixin.create(UnauthenticatedRouteMixin, {
+  async afterModel(
+    _,
+    {
+      queryParams: { state }
+    }
+  ) {
+    if (!endSessionEndpoint) {
+      this.session.invalidate();
+    }
+
+    this._handleRedirect();
+  },
+
+  _handleRedirect() {
+    const state = v4();
+
+    this.session.set("data.state", state);
+
+    const redirectUri = `${location.protocol}//${location.host}${logoutRoute}`;
+
+    location.replace(
+      `${host}${endSessionEndpoint}?` +
+        `post_logout_redirect_uri=${redirectUri}` +
+        `state=${state}`
+    );
+  }
+});

--- a/addon/mixins/oidc-end-session-route-mixin.js
+++ b/addon/mixins/oidc-end-session-route-mixin.js
@@ -33,6 +33,8 @@ export default Mixin.create({
     const redirectUri = `${location.protocol}//${location.host}${logoutRoute}`;
     const idToken = this.session.get("data.authenticated.id_token");
 
+    this.session.invalidate();
+
     location.replace(
       `${host}${endSessionEndpoint}?` +
         `id_token_hint=${idToken}&` +
@@ -47,7 +49,5 @@ export default Mixin.create({
     }
 
     this.session.set("data.state", undefined);
-
-    this.session.invalidate();
   }
 });

--- a/tests/dummy/config/environment.js
+++ b/tests/dummy/config/environment.js
@@ -12,8 +12,9 @@ module.exports = function(environment) {
       clientId: "test-client",
       authEndpoint: "/protocol/openid-connect/auth",
       tokenEndpoint: "/protocol/openid-connect/token",
-      logoutEndpoint: "/protocol/openid-connect/logout",
-      userinfoEndpoint: "/protocol/openid-connect/userinfo"
+      endSessionEndpoint: "/protocol/openid-connect/logout",
+      userinfoEndpoint: "/protocol/openid-connect/userinfo",
+      afterLogoutUri: "http://localhost:4200"
     },
 
     EmberENV: {

--- a/tests/unit/mixins/oidc-end-session-route-mixin-test.js
+++ b/tests/unit/mixins/oidc-end-session-route-mixin-test.js
@@ -1,0 +1,33 @@
+import EmberObject from "@ember/object";
+import OIDCEndSessionRouteMixin from "ember-simple-auth-oidc/mixins/oidc-end-session-route-mixin";
+import { module, test } from "qunit";
+import { setupTest } from "ember-qunit";
+import config from "ember-get-config";
+
+const { endSessionEndpoint, afterLogoutUri } = config["ember-simple-auth-oidc"];
+
+module("Unit | Mixin | oidc-end-session-route-mixin", function(hooks) {
+  setupTest(hooks);
+
+  test("it can make an invalidate request", function(assert) {
+    assert.expect(3);
+
+    const Route = EmberObject.extend(OIDCEndSessionRouteMixin);
+
+    const subject = Route.create({
+      session: EmberObject.create({
+        data: { authenticated: { id_token: "myIdToken" } },
+        async invalidate() {}
+      }),
+      _redirectToUrl(url) {
+        assert.ok(new RegExp(endSessionEndpoint).test(url));
+        assert.ok(
+          new RegExp(`post_logout_redirect_uri=${afterLogoutUri}`).test(url)
+        );
+        assert.ok(new RegExp("id_token_hint=myIdToken").test(url));
+      }
+    });
+
+    subject.afterModel(null, { queryParams: {} });
+  });
+});


### PR DESCRIPTION
* Rename config param `logoutEndpoint` to `endSessionEndpoint`
* Add new config param `afterLogoutUri`
* Add new mixins `oidc-end-session-route-mixin` and `oidc-application-route-mixin`
* Correctly handle invalidate
* Remove multiple redirects after successful authentication (fixes ember `handlerInfo` bug)