### PR TITLE
Rework restore call

### DIFF
--- a/addon/authenticators/oidc.js
+++ b/addon/authenticators/oidc.js
@@ -65,7 +65,7 @@ export default BaseAuthenticator.extend({
    *
    * @return {Promise} The invalidate promise
    */
-  async invalidate() {
+  invalidate() {
     return RSVP.resolve(true);
   },
 
@@ -84,14 +84,14 @@ export default BaseAuthenticator.extend({
     const { refresh_token, expireTime } = sessionData;
 
     if (!refresh_token) {
-      return RSVP.reject("Refresh token is missing");
+      throw new Error("Refresh token is missing");
     }
 
     if (expireTime && expireTime <= new Date().getTime()) {
-      return RSVP.resolve(await this._refresh(refresh_token));
+      return await this._refresh(refresh_token);
     } else {
       this._scheduleRefresh(expireTime, refresh_token);
-      return RSVP.resolve(sessionData);
+      return sessionData;
     }
   },
 


### PR DESCRIPTION
At the moment the restore call always makes a refresh request,
which then updates the session. A session update triggers the
restore call (if not done by this exact restore call) which leads
to a infinite request loop a soon as two or more tabs of the app
using this addon are open.
To fix this the restore call only makes a refresh request if the
token actually expired. Otherwise just schedule a refresh which will
then make the actual refresh request.