### PR TITLE
Allow the use of a relative host url

### DIFF
--- a/addon/authenticators/oidc.js
+++ b/addon/authenticators/oidc.js
@@ -6,6 +6,7 @@ import RSVP from "rsvp";
 import Configuration from "ember-simple-auth/configuration";
 import { assert } from "@ember/debug";
 import config from "ember-simple-auth-oidc/config";
+import getAbsoluteUrl from "ember-simple-auth-oidc/utils/absoluteUrl";
 
 const {
   host,
@@ -17,7 +18,7 @@ const {
   expiresIn
 } = config;
 
-const getUrl = endpoint => `${host}${endpoint}`;
+const getUrl = endpoint => `${getAbsoluteUrl(host)}${endpoint}`;
 
 export default BaseAuthenticator.extend({
   ajax: service(),

--- a/addon/mixins/oidc-authentication-route-mixin.js
+++ b/addon/mixins/oidc-authentication-route-mixin.js
@@ -4,6 +4,7 @@ import { computed } from "@ember/object";
 import { inject as service } from "@ember/service";
 import Configuration from "ember-simple-auth/configuration";
 import config from "ember-simple-auth-oidc/config";
+import getAbsoluteUrl from "ember-simple-auth-oidc/utils/absoluteUrl";
 import v4 from "uuid/v4";
 import { assert } from "@ember/debug";
 
@@ -103,7 +104,7 @@ export default Mixin.create(UnauthenticatedRouteMixin, {
     this.session.set("data.state", state);
 
     this._redirectToUrl(
-      `${host}${authEndpoint}?` +
+      `${getAbsoluteUrl(host)}${authEndpoint}?` +
         `client_id=${clientId}&` +
         `redirect_uri=${this.redirectUri}&` +
         `response_type=code&` +

--- a/addon/mixins/oidc-end-session-route-mixin.js
+++ b/addon/mixins/oidc-end-session-route-mixin.js
@@ -1,6 +1,7 @@
 import Mixin from "@ember/object/mixin";
 import { inject as service } from "@ember/service";
 import config from "ember-simple-auth-oidc/config";
+import getAbsoluteUrl from "ember-simple-auth-oidc/utils/absoluteUrl";
 
 const { host, endSessionEndpoint, afterLogoutUri } = config;
 
@@ -20,12 +21,7 @@ export default Mixin.create({
     const params = [];
 
     if (afterLogoutUri) {
-      const redirectUri =
-        afterLogoutUri.indexOf("http") === 0
-          ? afterLogoutUri
-          : `${location.protocol}//${location.host}${afterLogoutUri}`;
-
-      params.push(`post_logout_redirect_uri=${redirectUri}`);
+      params.push(`post_logout_redirect_uri=${getAbsoluteUrl(afterLogoutUri)}`);
     }
 
     const idToken = this.session.get("data.authenticated.id_token");
@@ -35,7 +31,7 @@ export default Mixin.create({
 
     this.session.invalidate();
 
-    let endSessionUri = `${host}${endSessionEndpoint}`;
+    let endSessionUri = `${getAbsoluteUrl(host)}${endSessionEndpoint}`;
     if (params.length > 0) {
       endSessionUri = `${endSessionUri}?${params.join("&")}`;
     }

--- a/addon/utils/absoluteUrl.js
+++ b/addon/utils/absoluteUrl.js
@@ -1,0 +1,5 @@
+export default url => {
+  return url.indexOf("http") === 0
+    ? url
+    : `${location.protocol}//${location.host}${url}`;
+};

--- a/tests/unit/utils/absoluteUrl-test.js
+++ b/tests/unit/utils/absoluteUrl-test.js
@@ -1,0 +1,24 @@
+import getAbsoluteUrl from "ember-simple-auth-oidc/utils/absoluteUrl";
+import { module, test } from "qunit";
+import { setupTest } from "ember-qunit";
+
+module("Unit | Utils | absoluteUrl", function(hooks) {
+  setupTest(hooks);
+
+  test("it transforms a relative url to an absolute one", function(assert) {
+    assert.expect(1);
+
+    const url = "/login";
+    assert.equal(
+      getAbsoluteUrl(url),
+      `${location.protocol}//${location.host}/login`
+    );
+  });
+
+  test("it does not transform an absolute url", function(assert) {
+    assert.expect(1);
+
+    const url = "http://myTestHost/login";
+    assert.equal(getAbsoluteUrl(url), url);
+  });
+});


### PR DESCRIPTION
At the moment the host url defined in the config file needs to be
absolute (http://myhost/oidc). Now it is possible to use a relative
url (/oidc) which then automatically will be extended with the
current location protocol and host.