### PR TITLE
fix: Fix accessing of query parameters in the authentication route

### DIFF
--- a/addon/mixins/oidc-authentication-route-mixin.js
+++ b/addon/mixins/oidc-authentication-route-mixin.js
@@ -14,6 +14,11 @@ export default Mixin.create(UnauthenticatedRouteMixin, {
   session: service(),
   router: service(),
 
+  queryParams: {
+    code: { refreshModel: false },
+    state: { refreshModel: false }
+  },
+
   redirectUri: computed(function() {
     let { protocol, host } = location;
     let path = this.router.urlFor(Configuration.authenticationRoute);
@@ -39,14 +44,17 @@ export default Mixin.create(UnauthenticatedRouteMixin, {
    *
    * @param {*} model The model of the route
    * @param {Ember.Transition} transition The current transition
-   * @param {Object} transition.queryParams The query params of the transition
-   * @param {String} transition.queryParams.code The authentication code given by the identity provider
-   * @param {String} transition.queryParams.state The state given by the identity provider
+   * @param {Object} transition.to The destination of the transition
+   * @param {Object} transition.to.queryParams The query params of the transition
+   * @param {String} transition.to.queryParams.code The authentication code given by the identity provider
+   * @param {String} transition.to.queryParams.state The state given by the identity provider
    */
   async afterModel(
     _,
     {
-      queryParams: { code, state }
+      to: {
+        queryParams: { code, state }
+      }
     }
   ) {
     if (!authEndpoint) {

--- a/addon/mixins/oidc-authentication-route-mixin.js
+++ b/addon/mixins/oidc-authentication-route-mixin.js
@@ -49,19 +49,16 @@ export default Mixin.create(UnauthenticatedRouteMixin, {
    * @param {String} transition.to.queryParams.code The authentication code given by the identity provider
    * @param {String} transition.to.queryParams.state The state given by the identity provider
    */
-  async afterModel(
-    _,
-    {
-      to: {
-        queryParams: { code, state }
-      }
-    }
-  ) {
+  async afterModel(_, transition) {
     if (!authEndpoint) {
       throw new Error(
         "Please define all OIDC endpoints (auth, token, logout, userinfo)"
       );
     }
+
+    const { code, state } = transition.to
+      ? transition.to.queryParams
+      : transition.queryParams;
 
     if (code) {
       return await this._handleCallbackRequest(code, state);

--- a/tests/unit/mixins/oidc-authentication-route-mixin-test.js
+++ b/tests/unit/mixins/oidc-authentication-route-mixin-test.js
@@ -48,6 +48,26 @@ module("Unit | Mixin | oidc-authentication-route-mixin", function(hooks) {
     subject.afterModel(null, { to: { queryParams: { code: "sometestcode" } } });
   });
 
+  test("it can handle older version of router_js", function(assert) {
+    assert.expect(1);
+
+    let Route = EmberObject.extend(OIDCAuthenticationRouteMixin);
+
+    let subject = Route.create({
+      redirectUri: "test",
+      session: EmberObject.create({
+        data: {
+          authenticated: {}
+        },
+        async authenticate(_, { code }) {
+          assert.equal(code, "sometestcode");
+        }
+      })
+    });
+
+    subject.afterModel(null, { queryParams: { code: "sometestcode" } });
+  });
+
   test("it can handle a failing authentication", function(assert) {
     assert.expect(2);
 

--- a/tests/unit/mixins/oidc-authentication-route-mixin-test.js
+++ b/tests/unit/mixins/oidc-authentication-route-mixin-test.js
@@ -25,7 +25,7 @@ module("Unit | Mixin | oidc-authentication-route-mixin", function(hooks) {
       }
     });
 
-    subject.afterModel(null, { queryParams: {} });
+    subject.afterModel(null, { to: { queryParams: {} } });
   });
 
   test("it can handle a request with an authentication code", function(assert) {
@@ -45,7 +45,7 @@ module("Unit | Mixin | oidc-authentication-route-mixin", function(hooks) {
       })
     });
 
-    subject.afterModel(null, { queryParams: { code: "sometestcode" } });
+    subject.afterModel(null, { to: { queryParams: { code: "sometestcode" } } });
   });
 
   test("it can handle a failing authentication", function(assert) {
@@ -69,7 +69,9 @@ module("Unit | Mixin | oidc-authentication-route-mixin", function(hooks) {
     // fails because the state is not correct (CSRF)
     subject
       .afterModel(null, {
-        queryParams: { code: "sometestcode", state: "state1" }
+        to: {
+          queryParams: { code: "sometestcode", state: "state1" }
+        }
       })
       .catch(e => {
         assert.ok(/State did not match/.test(e.message));
@@ -82,7 +84,9 @@ module("Unit | Mixin | oidc-authentication-route-mixin", function(hooks) {
     // fails because of the error in authenticate
     assert.rejects(
       subject.afterModel(null, {
-        queryParams: { code: "sometestcode", state: "state2" }
+        to: {
+          queryParams: { code: "sometestcode", state: "state2" }
+        }
       }),
       Error
     );


### PR DESCRIPTION
This is necessary because of a change in the router_js library which
transforms Transition.queryParams into a symbol

https://github.com/tildeio/router.js/commit/a481f0acbe7275e8309867046f1e89941ff70f6a#diff-7da86d75fbaeb445442c6dd0697adc39