### PR TITLE
feat: handle `attemptedTransition`

### DIFF
--- a/addon/mixins/oidc-authentication-route-mixin.js
+++ b/addon/mixins/oidc-authentication-route-mixin.js
@@ -89,6 +89,16 @@ export default Mixin.create(UnauthenticatedRouteMixin, {
     }
 
     this.session.set("data.state", undefined);
+    /**
+     * If there is a stored `continueTransition` URL, create a new transition
+     * object and store it in the `ember-simple-auth` `attemptedTransition`
+     * property. This will trigger the transition after a successful authentication.
+     */
+    this.session.set(
+      "attemptedTransition",
+      this.transitionTo(this.session.get("data.continueTransition")).abort()
+    );
+    this.session.set("data.continueTransition", undefined);
 
     await this.session.authenticate("authenticator:oidc", {
       code
@@ -107,6 +117,14 @@ export default Mixin.create(UnauthenticatedRouteMixin, {
     let state = v4();
 
     this.session.set("data.state", state);
+    /**
+     * Store the attemptedTransition URL in the localstorage so when the user returns after
+     * the login he can be sent to the initial destination.
+     */
+    this.session.set(
+      "data.continueTransition",
+      this.session.get("attemptedTransition.intent.url")
+    );
 
     this._redirectToUrl(
       `${getAbsoluteUrl(host)}${authEndpoint}?` +

--- a/tests/unit/mixins/oidc-authentication-route-mixin-test.js
+++ b/tests/unit/mixins/oidc-authentication-route-mixin-test.js
@@ -42,7 +42,10 @@ module("Unit | Mixin | oidc-authentication-route-mixin", function(hooks) {
         async authenticate(_, { code }) {
           assert.equal(code, "sometestcode");
         }
-      })
+      }),
+      transitionTo() {
+        return { abort() {} };
+      }
     });
 
     subject.afterModel(null, { to: { queryParams: { code: "sometestcode" } } });
@@ -62,7 +65,10 @@ module("Unit | Mixin | oidc-authentication-route-mixin", function(hooks) {
         async authenticate(_, { code }) {
           assert.equal(code, "sometestcode");
         }
-      })
+      }),
+      transitionTo() {
+        return { abort() {} };
+      }
     });
 
     subject.afterModel(null, { queryParams: { code: "sometestcode" } });


### PR DESCRIPTION
`ember-simple-auth` handles attempted transitions which are aborted by
the authentication process. Since the oidc addon redirects the page, the
attempted transition is lost and the user will always end up on the
index (or `routeAfterAuthentication`) page. This update will store the
attempted transition and recreate it after a successful login.