### PR TITLE
feat(redirect): add option to forward specific query params to idp

### DIFF
--- a/addon/mixins/oidc-authentication-route-mixin.js
+++ b/addon/mixins/oidc-authentication-route-mixin.js
@@ -8,7 +8,7 @@ import getAbsoluteUrl from "ember-simple-auth-oidc/utils/absoluteUrl";
 import v4 from "uuid/v4";
 import { assert } from "@ember/debug";
 
-const { host, clientId, authEndpoint, scope } = config;
+const { host, clientId, authEndpoint, scope, forwardParams } = config;
 
 export default Mixin.create(UnauthenticatedRouteMixin, {
   session: service(),
@@ -56,15 +56,18 @@ export default Mixin.create(UnauthenticatedRouteMixin, {
       );
     }
 
-    const { code, state } = transition.to
+    const queryParams = transition.to
       ? transition.to.queryParams
       : transition.queryParams;
 
-    if (code) {
-      return await this._handleCallbackRequest(code, state);
+    if (queryParams.code) {
+      return await this._handleCallbackRequest(
+        queryParams.code,
+        queryParams.state
+      );
     }
 
-    return this._handleRedirectRequest();
+    return this._handleRedirectRequest(queryParams);
   },
 
   /**
@@ -113,7 +116,7 @@ export default Mixin.create(UnauthenticatedRouteMixin, {
    * match this state, otherwise the authentication will fail to prevent from
    * CSRF attacks.
    */
-  _handleRedirectRequest() {
+  _handleRedirectRequest(queryParams) {
     let state = v4();
 
     this.session.set("data.state", state);
@@ -126,13 +129,21 @@ export default Mixin.create(UnauthenticatedRouteMixin, {
       this.session.get("attemptedTransition.intent.url")
     );
 
+    const forwarded = forwardParams
+      ? forwardParams
+          .filter(key => queryParams[key])
+          .map(key => `&${key}=${queryParams[key]}`)
+          .join()
+      : "";
+
     this._redirectToUrl(
       `${getAbsoluteUrl(host)}${authEndpoint}?` +
         `client_id=${clientId}&` +
         `redirect_uri=${this.redirectUri}&` +
         `response_type=code&` +
         `state=${state}&` +
-        `scope=${scope}`
+        `scope=${scope}` +
+        forwarded
     );
   }
 });


### PR DESCRIPTION
This is useful for features like Keycloak's "kc_idp_hint",
which allows to "hint" a specific identity provider for logging in to
Keycloak: When the application has a configured forwardParam "keycloak",
opening the app at http://my-app.com?kc_idp_hint=myidp will
automatically use the specified IDP (in this case "myidp") if not logged in, and otherwise the
user is already at the right place.