### PR TITLE
feat(redirect): add support for login_hint

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # ember-simple-auth-oidc
+
 [![npm version](https://badge.fury.io/js/ember-simple-auth-oidc.svg)](https://www.npmjs.com/package/ember-simple-auth-oidc)
 [![Build Status](https://travis-ci.com/adfinis-sygroup/ember-simple-auth-oidc.svg?branch=master)](https://travis-ci.com/adfinis-sygroup/ember-simple-auth-oidc)
 [![semantic-release](https://img.shields.io/badge/%20%20%F0%9F%93%A6%F0%9F%9A%80-semantic--release-e10079.svg)](https://github.com/semantic-release/semantic-release)
-
 
 A [Ember Simple Auth](http://ember-simple-auth.com) addon which implements the
 OpenID Connect [Authorization Code Flow](https://openid.net/specs/openid-connect-core-1_0.html#CodeFlowAuth).
@@ -82,12 +82,12 @@ module.exports = function(environment) {
       clientId: "test",
       authEndpoint: "/authorize",
       tokenEndpoint: "/token",
-      userinfoEndpoint: "/userinfo",
+      userinfoEndpoint: "/userinfo"
     }
     // ...
-  }
+  };
   return ENV;
-}
+};
 ```
 
 Here is a complete list of all possible config options:
@@ -134,6 +134,10 @@ Default is `Authorization`.
 
 **authPrefix** \<String\> (optional)  
 Prefix of the authentication token. Default is `Bearer`.
+
+**loginHintName** \<String\> (optional)  
+Name of the `login_hint` query paramter which is being forwarded to the authorization server if it is present.
+This option allows overriding the default name `login_hint`.
 
 ## Contributing
 

--- a/tests/dummy/config/environment.js
+++ b/tests/dummy/config/environment.js
@@ -14,7 +14,8 @@ module.exports = function(environment) {
       tokenEndpoint: "/protocol/openid-connect/token",
       endSessionEndpoint: "/protocol/openid-connect/logout",
       userinfoEndpoint: "/protocol/openid-connect/userinfo",
-      afterLogoutUri: "http://localhost:4200"
+      afterLogoutUri: "http://localhost:4200",
+      loginHintName: "custom_login_hint"
     },
 
     EmberENV: {

--- a/tests/unit/mixins/oidc-authentication-route-mixin-test.js
+++ b/tests/unit/mixins/oidc-authentication-route-mixin-test.js
@@ -18,10 +18,10 @@ module("Unit | Mixin | oidc-authentication-route-mixin", function(hooks) {
       redirectUri: "test",
       session: EmberObject.create({ data: { authenticated: {} } }),
       _redirectToUrl(url) {
-        assert.ok(new RegExp(authEndpoint).test(url));
+        assert.ok(url.includes(authEndpoint));
 
-        assert.ok(new RegExp(`client_id=${clientId}`).test(url));
-        assert.ok(new RegExp("redirect_uri=test").test(url));
+        assert.ok(url.includes(`client_id=${clientId}`));
+        assert.ok(url.includes("redirect_uri=test"));
       }
     });
 
@@ -116,5 +116,27 @@ module("Unit | Mixin | oidc-authentication-route-mixin", function(hooks) {
       }),
       Error
     );
+  });
+
+  test("it forwards customized login_hint param", function(assert) {
+    assert.expect(4);
+
+    let Route = EmberObject.extend(OIDCAuthenticationRouteMixin);
+
+    let subject = Route.create({
+      redirectUri: "test",
+      session: EmberObject.create({ data: { authenticated: {} } }),
+      _redirectToUrl(url) {
+        assert.ok(url.includes(authEndpoint));
+
+        assert.ok(url.includes(`client_id=${clientId}`));
+        assert.ok(url.includes("redirect_uri=test"));
+        assert.ok(url.includes("custom_login_hint=my-idp"));
+      }
+    });
+
+    subject.afterModel(null, {
+      to: { queryParams: { custom_login_hint: "my-idp" } }
+    });
   });
 });


### PR DESCRIPTION
This allows "hinting" a specific identity provider to the authentication
server.

Example: Upon opening the app at http://my-app.com?login_hint=myidp
will automatically use the specified IDP (in this case "myidp") if not logged in.

This also adds a new config option "loginHintName" that allows using a
different parameter name (e.g. Keycloak's `kc_idp_hint`).