### PR TITLE
fix(dummy-app): fix handling of `queryParams` in dummy

### DIFF
--- a/tests/dummy/app/routes/oidc.js
+++ b/tests/dummy/app/routes/oidc.js
@@ -1,12 +1,10 @@
 import Route from "@ember/routing/route";
 
 export default Route.extend({
-  redirect(
-    _,
-    {
-      queryParams: { redirect_uri, state }
-    }
-  ) {
+  redirect(_, transition) {
+    const { redirect_uri, state } = transition.to
+      ? transition.to.queryParams
+      : transition.queryParams;
     window.location.replace(`${redirect_uri}?code=123456789&state=${state}`);
   }
 });


### PR DESCRIPTION
The dummy app was not adapted to the transition changes in which the
queryParams are set on `transition.to` instead of `transition` directly. Add
the correct handling for both cases.