### PR TITLE
fix(authenticator): await successful retry before setting the session

### DIFF
--- a/addon/authenticators/oidc.js
+++ b/addon/authenticators/oidc.js
@@ -123,7 +123,13 @@ export default BaseAuthenticator.extend({
         (isServerError(e) || isAbortError(e) || isTimeoutError(e)) &&
         retryCount < amountOfRetries - 1
       ) {
-        later(this, this._refresh, refresh_token, retryCount + 1, retryTimeout);
+        return new Promise(resolve => {
+          later(
+            this,
+            () => resolve(this._refresh(refresh_token, retryCount + 1)),
+            retryTimeout
+          );
+        });
       } else {
         throw e;
       }


### PR DESCRIPTION
Currently if a retry fails, `undefined` is set as the session as we do not return anything in case we start a retry. Now the retries are blocking and the session is ONLY set if either a retry is successful or the last retry fails.