### PR TITLE
Allow custom authenticationRoute / redirectUri

### DIFF
--- a/addon/mixins/oidc-authentication-route-mixin.js
+++ b/addon/mixins/oidc-authentication-route-mixin.js
@@ -21,6 +21,9 @@ export default Mixin.create(UnauthenticatedRouteMixin, {
 
   redirectUri: computed(function() {
     let { protocol, host } = location;
+    let route = this.authenticationRoute;
+    if (!route)
+      route = Configuration.authenticationRoute;
     let path = this.router.urlFor(Configuration.authenticationRoute);
 
     return `${protocol}//${host}${path}`;

--- a/addon/mixins/oidc-authentication-route-mixin.js
+++ b/addon/mixins/oidc-authentication-route-mixin.js
@@ -21,7 +21,9 @@ export default Mixin.create(UnauthenticatedRouteMixin, {
 
   redirectUri: computed(function() {
     let { protocol, host } = location;
-    let path = this.router.urlFor(this.authenticationRoute || Configuration.authenticationRoute);
+    let path = this.router.urlFor(
+      this.authenticationRoute || Configuration.authenticationRoute
+    );
     return `${protocol}//${host}${path}`;
   }),
 

--- a/addon/mixins/oidc-authentication-route-mixin.js
+++ b/addon/mixins/oidc-authentication-route-mixin.js
@@ -24,7 +24,7 @@ export default Mixin.create(UnauthenticatedRouteMixin, {
     let route = this.authenticationRoute;
     if (!route)
       route = Configuration.authenticationRoute;
-    let path = this.router.urlFor(Configuration.authenticationRoute);
+    let path = this.router.urlFor(route);
 
     return `${protocol}//${host}${path}`;
   }),

--- a/addon/mixins/oidc-authentication-route-mixin.js
+++ b/addon/mixins/oidc-authentication-route-mixin.js
@@ -22,8 +22,9 @@ export default Mixin.create(UnauthenticatedRouteMixin, {
   redirectUri: computed(function() {
     let { protocol, host } = location;
     let route = this.authenticationRoute;
-    if (!route)
+    if (!route) { 
       route = Configuration.authenticationRoute;
+    }
     let path = this.router.urlFor(route);
 
     return `${protocol}//${host}${path}`;

--- a/addon/mixins/oidc-authentication-route-mixin.js
+++ b/addon/mixins/oidc-authentication-route-mixin.js
@@ -21,12 +21,7 @@ export default Mixin.create(UnauthenticatedRouteMixin, {
 
   redirectUri: computed(function() {
     let { protocol, host } = location;
-    let route = this.authenticationRoute;
-    if (!route) { 
-      route = Configuration.authenticationRoute;
-    }
-    let path = this.router.urlFor(route);
-
+    let path = this.router.urlFor(this.authenticationRoute || Configuration.authenticationRoute);
     return `${protocol}//${host}${path}`;
   }),
 


### PR DESCRIPTION
Without this change setting the property `authenticationRoute` (from http://ember-simple-auth.com/api/classes/AuthenticatedRouteMixin.html) on has no effect.