### PR TITLE
feat: remove support for node 8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: node_js
 node_js:
   # we recommend testing addons with the same minimum supported node version as Ember CLI
   # so that your addon works for all apps
-  - "8"
+  - "10"
 
 sudo: false
 dist: trusty

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "qunit-dom": "0.9.2"
   },
   "engines": {
-    "node": "8.* || >= 10.*"
+    "node": "10.* || >= 12.*"
   },
   "ember": {
     "edition": "octane"


### PR DESCRIPTION
BREAKING CHANGE: Node version 8.x is not supported anymore since it's
not a maintained LTS version.