### PR TITLE
feat: add client_secret for authorization token

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,9 @@ Amount of retries should be made if the request to fetch a new token fails. Defa
 **retryTimeout** `<Number>` (optional)  
 Timeout in milliseconds between each retry if a token refresh should fail. Default is `3000`.
 
+**clientSecret** `<String>` (optional)
+Specifies the `client_secret` key when obtaining authorization token.
+
 ## Contributing
 
 ### Installation

--- a/addon/authenticators/oidc.js
+++ b/addon/authenticators/oidc.js
@@ -115,7 +115,8 @@ export default BaseAuthenticator.extend({
           refresh_token,
           client_id: clientId,
           grant_type: "refresh_token",
-          redirect_uri: this.redirectUri
+          redirect_uri: this.redirectUri,
+          client_secret: clientSecret
         }
       });
       return this._handleAuthResponse(data);

--- a/addon/authenticators/oidc.js
+++ b/addon/authenticators/oidc.js
@@ -59,7 +59,8 @@ export default BaseAuthenticator.extend({
         client_id: clientId,
         grant_type: "authorization_code",
         redirect_uri: this.redirectUri,
-        client_secret: clientSecret
+        client_secret: clientSecret,
+        scope: "openid profile email offline_access"
       }
     });
 

--- a/addon/authenticators/oidc.js
+++ b/addon/authenticators/oidc.js
@@ -17,7 +17,8 @@ const {
   authPrefix,
   expiresIn,
   amountOfRetries,
-  retryTimeout
+  retryTimeout,
+  clientSecret
 } = config;
 
 const getUrl = endpoint => `${getAbsoluteUrl(host)}${endpoint}`;
@@ -57,7 +58,8 @@ export default BaseAuthenticator.extend({
         code,
         client_id: clientId,
         grant_type: "authorization_code",
-        redirect_uri: this.redirectUri
+        redirect_uri: this.redirectUri,
+        client_secret: clientSecret
       }
     });
 


### PR DESCRIPTION
I am using Azure AD for my OIDC Provider and I need to provide a client secret, client assertion, or upload a certificate to Azure in order to get an authorization token. A supposed workaround is to treat the application as a public client in Azure, but that did not work and it is not recommended for web apps anyways.
From Microsoft on the `client_secret` parameter ([link](https://docs.microsoft.com/en-us/azure/active-directory-b2c/authorization-code-flow)):

> The application secret that was generated in the Azure portal. Client secrets are used in this flow for Web App scenarios, where the client can securely store a client secret. For Native App (public client) scenarios, client secrets cannot be securely stored, and therefore are not used in this call. If you use a client secret, please change it on a periodic basis.