### PR TITLE
feat: support url for userinfoEndpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,7 @@ End session endpoint at the authorization server.
 
 **userinfoEndpoint** `<String>`  
 Userinfo endpoint at the authorization server.
+Can be a URL (SSL required) or a path of the `host`.
 
 **afterLogoutUri** `<String>` (optional)  
 A relative or absolute URI to which will be redirected after logout / end session.

--- a/addon/authenticators/oidc.js
+++ b/addon/authenticators/oidc.js
@@ -168,7 +168,11 @@ export default BaseAuthenticator.extend({
    * @returns {Object} Object containing the user information
    */
   async _getUserinfo(accessToken) {
-    const userinfo = await this.get("ajax").request(getUrl(userinfoEndpoint), {
+    const endpointIsUrl = userinfoEndpoint.includes("https://");
+    const userinfoUrl = endpointIsUrl
+      ? userinfoEndpoint
+      : getUrl(userinfoEndpoint);
+    const userinfo = await this.get("ajax").request(userinfoUrl, {
       headers: { Authorization: `${authPrefix} ${accessToken}` },
       responseType: "application/json"
     });


### PR DESCRIPTION
Since Azure AD uses a different host for `userinfo`, I added logic to support URLs for the `userinfoEndpoint`.