### PR TITLE
feat: add support for ember-simple-auth 3

### DIFF
--- a/addon/mixins/oidc-authentication-route-mixin.js
+++ b/addon/mixins/oidc-authentication-route-mixin.js
@@ -4,7 +4,6 @@ import Mixin from "@ember/object/mixin";
 import { inject as service } from "@ember/service";
 import config from "ember-simple-auth-oidc/config";
 import getAbsoluteUrl from "ember-simple-auth-oidc/utils/absoluteUrl";
-import Configuration from "ember-simple-auth/configuration";
 import UnauthenticatedRouteMixin from "ember-simple-auth/mixins/unauthenticated-route-mixin";
 import { v4 } from "uuid";
 
@@ -19,11 +18,9 @@ export default Mixin.create(UnauthenticatedRouteMixin, {
     state: { refreshModel: false },
   },
 
-  redirectUri: computed("authenticationRoute", function () {
+  redirectUri: computed("authenticationRoute", "routeName", function () {
     const { protocol, host } = location;
-    const path = this.router.urlFor(
-      this.authenticationRoute || Configuration.authenticationRoute
-    );
+    const path = this.router.urlFor(this.routeName);
     return `${protocol}//${host}${path}`;
   }),
 
@@ -96,6 +93,7 @@ export default Mixin.create(UnauthenticatedRouteMixin, {
 
     await this.session.authenticate("authenticator:oidc", {
       code,
+      redirectUri: this.redirectUri,
     });
   },
 

--- a/tests/dummy/config/environment.js
+++ b/tests/dummy/config/environment.js
@@ -16,6 +16,7 @@ module.exports = function (environment) {
       userinfoEndpoint: "/protocol/openid-connect/userinfo",
       afterLogoutUri: "http://localhost:4200",
       loginHintName: "custom_login_hint",
+      expiresIn: 60000, // Short expire time (60s) for testing purpose
     },
 
     EmberENV: {


### PR DESCRIPTION
In ember-simple-auth 3 the configuration option `authenticationRoute`
was removed. Adjust the oidc addon so it works with ember-simple-auth 3
and previous versions. Only the `redirectUri` parts needed to be changed
for this, which was handled a bit strangly from the beginning anyway.