### PR TITLE
feat(single-logout): separate session invalidate and oidc logout

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,27 @@ export default ApolloService {
 });
 ```
 
+### Logout / Explicit invalidation
+
+There are two ways to invalidate (logout) the current session:
+
+```js
+session.invalidate();
+```
+
+The session `invalidate` method ends the current ember-simple-auth session and therefore performs a
+logout on the ember application. Note that the session on the authorization server is not invalidated
+this way and a new token/session can simply be obtained when doing the authentication process again.
+
+```js
+session.singleLogout();
+```
+
+The session `singleLogout` method will invalidate the current ember-simple-auth session and after that
+call the `end-session` endpoint of the authorization server. This will result in a logout of the
+ember application and additionally invalidate the session on the authorization server which will logout
+the user of all applications using this authorization server!
+
 ## Configuration
 
 The addon can be configured in the project's `environment.js` file with the key `ember-simple-auth-oidc`.

--- a/addon/authenticators/oidc.js
+++ b/addon/authenticators/oidc.js
@@ -11,6 +11,8 @@ const {
   host,
   tokenEndpoint,
   userinfoEndpoint,
+  endSessionEndpoint,
+  afterLogoutUri,
   clientId,
   refreshLeeway,
   authPrefix,
@@ -68,12 +70,44 @@ export default BaseAuthenticator.extend({
   },
 
   /**
-   * Invalidate the current session with the refresh token
+   * Invalidate the current ember simple auth session
    *
    * @return {Promise} The invalidate promise
    */
   invalidate() {
     return resolve(true);
+  },
+
+  /**
+   * Invalidates the current session (of this application) and calls the
+   * `end-session` endpoint of the authorization server, which will
+   * invalidate all sessions which are handled by the authorization server
+   * (possible for multiple applications).
+   *
+   * @param {String} idToken The id_token of the session to invalidate
+   */
+  singleLogout(idToken) {
+    if (!endSessionEndpoint) {
+      return;
+    }
+
+    const params = [];
+
+    if (afterLogoutUri) {
+      params.push(`post_logout_redirect_uri=${getAbsoluteUrl(afterLogoutUri)}`);
+    }
+
+    if (idToken) {
+      params.push(`id_token_hint=${idToken}`);
+    }
+
+    this._redirectToUrl(
+      `${getAbsoluteUrl(endSessionEndpoint, host)}?${params.join("&")}`
+    );
+  },
+
+  _redirectToUrl(url) {
+    location.replace(url);
   },
 
   /**

--- a/addon/index.js
+++ b/addon/index.js
@@ -1,9 +1,20 @@
 import { set } from "@ember/object";
+import Ember from "ember";
+import config from "ember-simple-auth-oidc/config";
+import getAbsoluteUrl from "ember-simple-auth-oidc/utils/absoluteUrl";
+
+const { afterLogoutUri } = config;
 
 export const handleUnauthorized = (session) => {
   if (session.isAuthenticated) {
     set(session, "data.nextURL", location.href.replace(location.origin, ""));
     session.invalidate();
+
+    const url = afterLogoutUri || "";
+
+    if (!Ember.testing) {
+      location.replace(getAbsoluteUrl(url));
+    }
   }
 };
 

--- a/addon/services/session.js
+++ b/addon/services/session.js
@@ -1,0 +1,15 @@
+import SessionServiceESA from "ember-simple-auth/services/session";
+
+export default SessionServiceESA.extend({
+  singleLogout() {
+    const session = this.session; // InternalSession
+    const authenticator = session._lookupAuthenticator(session.authenticator);
+    const idToken = this.data.authenticated.id_token;
+
+    // Invalidate the ember-simple-auth session
+    this.invalidate();
+
+    // Trigger a single logout on the authorization server
+    return authenticator.singleLogout(idToken);
+  },
+});

--- a/app/services/session.js
+++ b/app/services/session.js
@@ -1,0 +1,1 @@
+export { default } from "ember-simple-auth-oidc/services/session";

--- a/package.json
+++ b/package.json
@@ -79,7 +79,8 @@
     "edition": "octane"
   },
   "ember-addon": {
-    "configPath": "tests/dummy/config"
+    "configPath": "tests/dummy/config",
+    "after": "ember-simple-auth"
   },
   "release": {
     "extends": "@adfinis-sygroup/semantic-release-config"

--- a/tests/dummy/app/adapters/application.js
+++ b/tests/dummy/app/adapters/application.js
@@ -1,0 +1,4 @@
+import JSONAPIAdapter from "@ember-data/adapter/json-api";
+import OIDCAdapterMixin from "ember-simple-auth-oidc/mixins/oidc-adapter-mixin";
+
+export default JSONAPIAdapter.extend(OIDCAdapterMixin, {});

--- a/tests/dummy/app/controllers/application.js
+++ b/tests/dummy/app/controllers/application.js
@@ -7,6 +7,6 @@ export default class ApplicationController extends Controller {
 
   @action
   logout() {
-    this.session.invalidate();
+    this.session.singleLogout();
   }
 }

--- a/tests/dummy/app/models/user.js
+++ b/tests/dummy/app/models/user.js
@@ -1,0 +1,6 @@
+import Model, { attr } from "@ember-data/model";
+
+export default class extends Model {
+  @attr username;
+  @attr email;
+}

--- a/tests/dummy/app/router.js
+++ b/tests/dummy/app/router.js
@@ -12,6 +12,7 @@ Router.map(function () {
   this.route("login");
   this.route("protected", function () {
     this.route("profile");
+    this.route("secret");
   });
   this.route("oidc", {
     path: "realms/test-realm/protocol/openid-connect/auth",

--- a/tests/dummy/app/routes/protected/secret.js
+++ b/tests/dummy/app/routes/protected/secret.js
@@ -1,7 +1,5 @@
 import Route from "@ember/routing/route";
 
 export default Route.extend({
-  model() {
-    return this.store.findRecord("user", 1);
-  },
+  model() {},
 });

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -1,6 +1,7 @@
 <LinkTo @route="index">Index</LinkTo>
-<LinkTo @route="protected">Protected</LinkTo>
+<LinkTo @route="protected">Internal</LinkTo>
 {{#if this.session.isAuthenticated}}
+  <LinkTo @route="protected.profile">Profile (401 handling demo)</LinkTo>
   <a href="#" {{on "click" this.logout}}>Logout</a>
 {{else}}
   <LinkTo @route="login">Login</LinkTo>

--- a/tests/dummy/app/templates/protected/secret.hbs
+++ b/tests/dummy/app/templates/protected/secret.hbs
@@ -1,0 +1,1 @@
+You found the secret!

--- a/tests/dummy/mirage/config.js
+++ b/tests/dummy/mirage/config.js
@@ -1,3 +1,5 @@
+import { Response } from "miragejs";
+
 export default function () {
   this.urlPrefix = "http://localhost:4200";
   this.namespace = "";
@@ -7,10 +9,15 @@ export default function () {
     return {
       access_token: "access.token",
       refresh_token: "refresh.token",
+      id_token: "id.token",
     };
   });
 
   this.get("/realms/test-realm/protocol/openid-connect/userinfo", function () {
     return { sub: 1 };
+  });
+
+  this.get("/users/1", function () {
+    return new Response(401);
   });
 }

--- a/tests/unit/authenticators/oidc-test.js
+++ b/tests/unit/authenticators/oidc-test.js
@@ -1,6 +1,9 @@
 import setupMirage from "ember-cli-mirage/test-support/setup-mirage";
+import config from "ember-get-config";
 import { setupTest } from "ember-qunit";
 import { module, test } from "qunit";
+
+const { endSessionEndpoint, afterLogoutUri } = config["ember-simple-auth-oidc"];
 
 const getTokenBody = (expired) => {
   const time = expired ? -30 : 120;
@@ -99,5 +102,21 @@ module("Unit | Authenticator | OIDC", function (hooks) {
     };
 
     subject._scheduleRefresh(new Date().getTime() + 500, "testtoken");
+  });
+
+  test("it can make a single logout", async function (assert) {
+    assert.expect(3);
+
+    const subject = this.owner.lookup("authenticator:oidc");
+
+    subject._redirectToUrl = (url) => {
+      assert.ok(new RegExp(endSessionEndpoint).test(url));
+      assert.ok(
+        new RegExp(`post_logout_redirect_uri=${afterLogoutUri}`).test(url)
+      );
+      assert.ok(new RegExp("id_token_hint=myIdToken").test(url));
+    };
+
+    subject.singleLogout("myIdToken");
   });
 });

--- a/tests/unit/mixins/oidc-application-route-mixin-test.js
+++ b/tests/unit/mixins/oidc-application-route-mixin-test.js
@@ -1,10 +1,7 @@
 import EmberObject from "@ember/object";
-import config from "ember-get-config";
 import { setupTest } from "ember-qunit";
 import OidcApplicationRouteMixin from "ember-simple-auth-oidc/mixins/oidc-application-route-mixin";
 import { module, test } from "qunit";
-
-const { endSessionEndpoint, afterLogoutUri } = config["ember-simple-auth-oidc"];
 
 module("Unit | Mixin | oidc-application-route-mixin", function (hooks) {
   setupTest(hooks);
@@ -13,39 +10,17 @@ module("Unit | Mixin | oidc-application-route-mixin", function (hooks) {
     assert.expect(1);
 
     const session = this.owner.lookup("service:session");
-    session.set("data.nextURL", "protected/profile");
+    session.set("data.nextURL", "protected/secret");
 
     const Route = EmberObject.extend(OidcApplicationRouteMixin);
 
     const subject = Route.create(this.owner.ownerInjection(), {
       session,
       replaceWith(url) {
-        assert.equal(url, "protected/profile");
+        assert.equal(url, "protected/secret");
       },
     });
 
     subject.sessionAuthenticated();
-  });
-
-  test("it can make an invalidate request", function (assert) {
-    assert.expect(3);
-
-    const Route = EmberObject.extend(OidcApplicationRouteMixin);
-
-    const subject = Route.create(this.owner.ownerInjection(), {
-      session: EmberObject.create({
-        data: { id_token_prev: "myIdToken" },
-        on() {},
-      }),
-      _redirectToUrl(url) {
-        assert.ok(new RegExp(endSessionEndpoint).test(url));
-        assert.ok(
-          new RegExp(`post_logout_redirect_uri=${afterLogoutUri}`).test(url)
-        );
-        assert.ok(new RegExp("id_token_hint=myIdToken").test(url));
-      },
-    });
-
-    subject.sessionInvalidated(null, { queryParams: {} });
   });
 });


### PR DESCRIPTION
There is a difference between a logout of the current application and a
logout on the authorization server. Until now the addon assumed if the
ember-simple-auth session is invalidated it should also call the
`end-session` endpoint of the authorization server which invalidates all
ongoing sessions in possible different applications. With the
introduction of the `singleLogout` function the application using this
addon can decide between invalidating the current ember-simple-auth
session or doing a global/single logout in addition.