### PR TITLE
feat(adapter)!: add oidc rest adapter and refactor adapter naming

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,18 +58,19 @@ export default class ProtectedRoute extends Route {
 
 To include authorization info in all Ember Data requests override `headers` in
 the application adapter and include `session.headers` alongside any other
-necessary headers. By extending the application adapter from the `OIDCAdapter`,
-the `access_token` is refreshed before Ember Data requests, if necessary. The
-`OIDCAdapter` also provides default headers with the authorization header
-included.
+necessary headers. By extending the application adapter from either of the
+provided `OIDCJSONAPIAdapter` or `OIDCRESTAdapter`, the `access_token` is 
+refreshed before Ember Data requests, if necessary. Both the `OIDCJSONAPIAdapter` 
+and the `OIDCRESTAdapter` also provide default headers with the authorization 
+header included.
 
 ```js
 // app/adapters/application.js
 
 import { inject as service } from "@ember/service";
-import OIDCAdapter from "ember-simple-auth-oidc/adapters/oidc-adapter";
+import OIDCJSONAPIAdapter from "ember-simple-auth-oidc/adapters/oidc-json-api-adapter";
 
-export default class ApplicationAdapter extends OIDCAdapter {
+export default class ApplicationAdapter extends OIDCJSONAPIAdapter {
   @service session;
 
   get headers() {
@@ -78,11 +79,11 @@ export default class ApplicationAdapter extends OIDCAdapter {
 }
 ```
 
-The `OIDCAdapter` already handles unauthorized requests and performs an 
-invalidation of the session which also remembers your visited URL. If you want 
-this behaviour for other request services as well, you can use the
-`handleUnauthorized` function. The following snippet shows an example
-`ember-apollo-client` afterware (error handling) implementation:
+Both the `OIDCJSONAPIAdapter` and `OIDCRESTAdapter` already handle unauthorized 
+requests and perform an invalidation of the session, which also remembers your 
+visited URL. If you want this behaviour for other request services as well, you 
+can use the `handleUnauthorized` function. The following snippet shows an 
+example `ember-apollo-client` afterware (error handling) implementation:
 
 ```js
 // app/services/apollo.js

--- a/addon/adapters/oidc-json-api-adapter.js
+++ b/addon/adapters/oidc-json-api-adapter.js
@@ -1,0 +1,47 @@
+import JSONAPIAdapter from "@ember-data/adapter/json-api";
+import { inject as service } from "@ember/service";
+import { handleUnauthorized } from "ember-simple-auth-oidc";
+
+export default class OIDCJSONAPIAdapter extends JSONAPIAdapter {
+  @service session;
+
+  constructor(...args) {
+    super(...args);
+
+    // Proxy ember-data requests to ensure prior token refresh
+    return new Proxy(this, {
+      get(target, prop, receiver) {
+        if (
+          [
+            "findRecord",
+            "createRecord",
+            "updateRecord",
+            "deleteRecord",
+            "findAll",
+            "query",
+            "findMany",
+          ].includes(prop)
+        ) {
+          return new Proxy(target[prop], {
+            async apply(...args) {
+              await target.session.refreshAuthentication.perform();
+              return Reflect.apply(...args);
+            },
+          });
+        }
+        return Reflect.get(target, prop, receiver);
+      },
+    });
+  }
+
+  get headers() {
+    return this.session.headers;
+  }
+
+  handleResponse(status, ...args) {
+    if (status === 401) {
+      handleUnauthorized(this.session);
+    }
+    return super.handleResponse(status, ...args);
+  }
+}

--- a/addon/adapters/oidc-rest-adapter.js
+++ b/addon/adapters/oidc-rest-adapter.js
@@ -1,8 +1,8 @@
-import JSONAPIAdapter from "@ember-data/adapter/json-api";
+import RESTAdapter from "@ember-data/adapter/rest";
 import { inject as service } from "@ember/service";
 import { handleUnauthorized } from "ember-simple-auth-oidc";
 
-export default class OIDCAdapter extends JSONAPIAdapter {
+export default class OIDCRESTAdapter extends RESTAdapter {
   @service session;
 
   constructor(...args) {

--- a/app/adapters/oidc-adapter.js
+++ b/app/adapters/oidc-adapter.js
@@ -1,1 +1,0 @@
-export { default } from "ember-simple-auth-oidc/adapters/oidc-adapter";

--- a/app/adapters/oidc-json-api-adapter.js
+++ b/app/adapters/oidc-json-api-adapter.js
@@ -1,0 +1,1 @@
+export { default } from "ember-simple-auth-oidc/adapters/oidc-json-api-adapter";

--- a/app/adapters/oidc-rest-adapter.js
+++ b/app/adapters/oidc-rest-adapter.js
@@ -1,0 +1,1 @@
+export { default } from "ember-simple-auth-oidc/adapters/oidc-rest-adapter";

--- a/tests/dummy/app/adapters/application.js
+++ b/tests/dummy/app/adapters/application.js
@@ -1,7 +1,7 @@
 import { inject as service } from "@ember/service";
-import OIDCAdapter from "ember-simple-auth-oidc/adapters/oidc-adapter";
+import OIDCJSONAPIAdapter from "ember-simple-auth-oidc/adapters/oidc-json-api-adapter";
 
-export default class ApplicationAdapter extends OIDCAdapter {
+export default class ApplicationAdapter extends OIDCJSONAPIAdapter {
   @service session;
 
   get headers() {

--- a/tests/unit/adapters/oidc-json-api-adapter-test.js
+++ b/tests/unit/adapters/oidc-json-api-adapter-test.js
@@ -1,0 +1,68 @@
+import { set } from "@ember/object";
+import setupMirage from "ember-cli-mirage/test-support/setup-mirage";
+import { setupTest } from "ember-qunit";
+import { module, test } from "qunit";
+
+module("Unit | Adapter | oidc json api adapter", function (hooks) {
+  setupTest(hooks);
+  setupMirage(hooks);
+
+  test("it sets the correct headers", async function (assert) {
+    assert.expect(1);
+
+    const adapter = this.owner.lookup("adapter:oidc-json-api-adapter");
+    const session = this.owner.lookup("service:session");
+    set(session, "session.isAuthenticated", true);
+    session.data.authenticated.access_token = "access.token";
+
+    assert.deepEqual(adapter.headers, { Authorization: "Bearer access.token" });
+  });
+
+  test("it refreshes the access token before ember-data requests", async function (assert) {
+    assert.expect(21);
+
+    const adapter = this.owner.lookup("adapter:oidc-json-api-adapter");
+
+    adapter.session.refreshAuthentication.perform = () => {
+      assert.step("refresh");
+    };
+
+    const mockAndTest = async (funcName) => {
+      adapter[funcName] = () => {
+        assert.step(funcName);
+      };
+
+      await adapter[funcName]();
+      assert.verifySteps(["refresh", funcName]);
+    };
+
+    await mockAndTest("findRecord");
+    await mockAndTest("createRecord");
+    await mockAndTest("updateRecord");
+    await mockAndTest("deleteRecord");
+    await mockAndTest("findAll");
+    await mockAndTest("query");
+    await mockAndTest("findMany");
+  });
+
+  test("it invalidates the session correctly on a 401 response", function (assert) {
+    assert.expect(3);
+
+    const adapter = this.owner.lookup("adapter:oidc-json-api-adapter");
+    const session = adapter.session;
+    session.session.content = {};
+    session.session.isAuthenticated = true;
+    session.invalidate = () => {
+      assert.step("invalidate");
+    };
+
+    adapter.handleResponse(401, {}, {}, {});
+
+    assert.strictEqual(
+      adapter.session.data.nextURL,
+      location.href.replace(location.origin, "")
+    );
+
+    assert.verifySteps(["invalidate"]);
+  });
+});

--- a/tests/unit/adapters/oidc-rest-adapter-test.js
+++ b/tests/unit/adapters/oidc-rest-adapter-test.js
@@ -3,14 +3,14 @@ import setupMirage from "ember-cli-mirage/test-support/setup-mirage";
 import { setupTest } from "ember-qunit";
 import { module, test } from "qunit";
 
-module("Unit | Adapter | oidc adapter", function (hooks) {
+module("Unit | Adapter | oidc rest adapter", function (hooks) {
   setupTest(hooks);
   setupMirage(hooks);
 
   test("it sets the correct headers", async function (assert) {
     assert.expect(1);
 
-    const adapter = this.owner.lookup("adapter:oidc-adapter");
+    const adapter = this.owner.lookup("adapter:oidc-rest-adapter");
     const session = this.owner.lookup("service:session");
     set(session, "session.isAuthenticated", true);
     session.data.authenticated.access_token = "access.token";
@@ -21,7 +21,7 @@ module("Unit | Adapter | oidc adapter", function (hooks) {
   test("it refreshes the access token before ember-data requests", async function (assert) {
     assert.expect(21);
 
-    const adapter = this.owner.lookup("adapter:oidc-adapter");
+    const adapter = this.owner.lookup("adapter:oidc-rest-adapter");
 
     adapter.session.refreshAuthentication.perform = () => {
       assert.step("refresh");
@@ -48,7 +48,7 @@ module("Unit | Adapter | oidc adapter", function (hooks) {
   test("it invalidates the session correctly on a 401 response", function (assert) {
     assert.expect(3);
 
-    const adapter = this.owner.lookup("adapter:oidc-adapter");
+    const adapter = this.owner.lookup("adapter:oidc-rest-adapter");
     const session = adapter.session;
     session.session.content = {};
     session.session.isAuthenticated = true;


### PR DESCRIPTION
BREAKING CHANGE: Include an adapter subclass of the Ember
RestAdapter to handle OIDC token refreshes and unauthorized
request handling. The existing OIDCadapter is renamed to
OIDCJSONAPIAdapter to clarify the base class origin.