### PR TITLE
fix(dummy): correct session setup and fix serializer deprecation

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,24 +112,10 @@ export default class CustomApolloService extends ApolloService {
 }
 ```
 
-[Ember Simple Auth v4.1.0](https://github.com/simplabs/ember-simple-auth/releases/tag/4.1.0) 
-encourages the manual setup of the session service in the `beforeModel` of the 
-application route.
+Ember Simple Auth encourages the manual setup of the session service in the `beforeModel` of the 
+application route, starting with [version 4.1.0](https://github.com/simplabs/ember-simple-auth/releases/tag/4.1.0). 
+The relevant changes are described in their [upgrade to v4 guide](https://github.com/simplabs/ember-simple-auth/blob/master/guides/upgrade-to-v4.md).
 
-```js
-// app/routes/application.js
-
-import Route from "@ember/routing/route";
-import { inject as service } from "@ember/service";
-
-export default class ApplicationRoute extends Route {
-  @service session;
-
-  async beforeModel() {
-    await this.session.setup();
-  }
-}
-```
 
 ### Logout / Explicit invalidation
 

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -5,6 +5,9 @@ const EmberAddon = require("ember-cli/lib/broccoli/ember-addon");
 module.exports = function (defaults) {
   const app = new EmberAddon(defaults, {
     // Add options here
+    "ember-simple-auth": {
+      useSessionSetupMethod: true,
+    },
   });
 
   /*

--- a/tests/dummy/app/serializers/application.js
+++ b/tests/dummy/app/serializers/application.js
@@ -1,0 +1,3 @@
+import JSONAPISerializer from "@ember-data/serializer/json-api";
+
+export default class ApplicationSerializer extends JSONAPISerializer {}


### PR DESCRIPTION
Add missing session setup configuration to dummy app to
adhere to upgrade guide v4 of ember-simple-auth. In addition,
fix defaultSerializer deprecation in dummy app adapter by adding
an application serializer in the dummy app.