### PR TITLE
fix(config): remove usage of ember-get-config

### DIFF
--- a/addon/config.js
+++ b/addon/config.js
@@ -1,7 +1,7 @@
-import config from "ember-get-config";
+import { getOwner } from "@ember/application";
 
-export default Object.assign(
-  {
+export function getConfig(owner) {
+  return {
     host: "http://localhost:4200",
     clientId: "client",
     authEndpoint: null,
@@ -18,6 +18,16 @@ export default Object.assign(
     authPrefix: "Bearer",
     amountOfRetries: 3,
     retryTimeout: 3000,
-  },
-  config["ember-simple-auth-oidc"] || {}
-);
+    ...(owner.resolveRegistration("config:environment")[
+      "ember-simple-auth-oidc"
+    ] ?? {}),
+  };
+}
+
+export default function config() {
+  return {
+    get() {
+      return getConfig(getOwner(this));
+    },
+  };
+}

--- a/addon/index.js
+++ b/addon/index.js
@@ -1,18 +1,18 @@
-import Ember from "ember";
-import config from "ember-simple-auth-oidc/config";
+import { getOwner } from "@ember/application";
+import { getConfig } from "ember-simple-auth-oidc/config";
 import getAbsoluteUrl from "ember-simple-auth-oidc/utils/absoluteUrl";
-
-const { afterLogoutUri } = config;
 
 export const handleUnauthorized = (session) => {
   if (session.isAuthenticated) {
     session.set("data.nextURL", location.href.replace(location.origin, ""));
     session.invalidate();
 
-    const url = afterLogoutUri || "";
+    const owner = getOwner(session);
 
-    if (!Ember.testing) {
-      location.replace(getAbsoluteUrl(url));
+    if (
+      owner.resolveRegistration("config:environment").environment !== "test"
+    ) {
+      location.replace(getAbsoluteUrl(getConfig(owner).afterLogoutUri || ""));
     }
   }
 };

--- a/addon/routes/oidc-authentication.js
+++ b/addon/routes/oidc-authentication.js
@@ -5,11 +5,11 @@ import config from "ember-simple-auth-oidc/config";
 import getAbsoluteUrl from "ember-simple-auth-oidc/utils/absoluteUrl";
 import { v4 } from "uuid";
 
-const { host, clientId, authEndpoint, scope, loginHintName } = config;
-
 export default class OIDCAuthenticationRoute extends Route {
   @service session;
   @service router;
+
+  @config config;
 
   queryParams = {
     code: { refreshModel: false },
@@ -52,7 +52,7 @@ export default class OIDCAuthenticationRoute extends Route {
    * @param {String} transition.to.queryParams.state The state given by the identity provider
    */
   async afterModel(_, transition) {
-    if (!authEndpoint) {
+    if (!this.config.authEndpoint) {
       throw new Error(
         "Please define all OIDC endpoints (auth, token, logout, userinfo)"
       );
@@ -127,19 +127,21 @@ export default class OIDCAuthenticationRoute extends Route {
     }
 
     // forward `login_hint` query param if present
-    const key = loginHintName || "login_hint";
+    const key = this.config.loginHintName || "login_hint";
 
     const search = [
-      `client_id=${clientId}`,
+      `client_id=${this.config.clientId}`,
       `redirect_uri=${this.redirectUri}`,
       `response_type=code`,
       `state=${state}`,
-      `scope=${scope}`,
+      `scope=${this.config.scope}`,
       queryParams[key] ? `${key}=${queryParams[key]}` : null,
     ]
       .filter(Boolean)
       .join("&");
 
-    this._redirectToUrl(`${getAbsoluteUrl(host)}${authEndpoint}?${search}`);
+    this._redirectToUrl(
+      `${getAbsoluteUrl(this.config.host)}${this.config.authEndpoint}?${search}`
+    );
   }
 }

--- a/addon/services/session.js
+++ b/addon/services/session.js
@@ -3,10 +3,10 @@ import { enqueueTask } from "ember-concurrency";
 import config from "ember-simple-auth-oidc/config";
 import SessionServiceESA from "ember-simple-auth/services/session";
 
-const { authHeaderName, authPrefix, tokenPropertyName } = config;
-
 export default class Service extends SessionServiceESA {
   @service router;
+
+  @config config;
 
   singleLogout() {
     const session = this.session; // InternalSession
@@ -36,8 +36,10 @@ export default class Service extends SessionServiceESA {
     const headers = {};
 
     if (this.isAuthenticated) {
-      const token = this.data.authenticated[tokenPropertyName];
-      Object.assign(headers, { [authHeaderName]: `${authPrefix} ${token}` });
+      const token = this.data.authenticated[this.config.tokenPropertyName];
+      Object.assign(headers, {
+        [this.config.authHeaderName]: `${this.config.authPrefix} ${token}`,
+      });
     }
 
     return headers;

--- a/package.json
+++ b/package.json
@@ -31,7 +31,6 @@
     "ember-cli-htmlbars": "^6.0.1",
     "ember-concurrency": "^2.2.0",
     "ember-fetch": "^8.1.1",
-    "ember-get-config": "^0.5.0",
     "ember-simple-auth": "^4.1.1",
     "tracked-built-ins": "^2.0.1",
     "uuid": "^8.3.2"

--- a/tests/unit/authenticators/oidc-test.js
+++ b/tests/unit/authenticators/oidc-test.js
@@ -1,10 +1,8 @@
 import { set } from "@ember/object";
 import setupMirage from "ember-cli-mirage/test-support/setup-mirage";
-import config from "ember-get-config";
 import { setupTest } from "ember-qunit";
+import { getConfig } from "ember-simple-auth-oidc/config";
 import { module, test } from "qunit";
-
-const { endSessionEndpoint, afterLogoutUri } = config["ember-simple-auth-oidc"];
 
 const getTokenBody = (expired) => {
   const time = expired ? -30 : 120;
@@ -75,6 +73,7 @@ module("Unit | Authenticator | OIDC", function (hooks) {
   test("it can make a single logout", async function (assert) {
     assert.expect(3);
 
+    const { endSessionEndpoint, afterLogoutUri } = getConfig(this.owner);
     const subject = this.owner.lookup("authenticator:oidc");
 
     subject._redirectToUrl = (url) => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -6005,15 +6005,6 @@ ember-fetch@^8.1.1:
     broccoli-file-creator "^1.1.1"
     ember-cli-babel "^7.0.0"
 
-ember-get-config@^0.5.0:
-  version "0.5.0"
-  resolved "https://registry.yarnpkg.com/ember-get-config/-/ember-get-config-0.5.0.tgz#8195f3e4c0ff0742182c81ae54aad78d07a24bcf"
-  integrity sha512-y1osD6g8wV/BlDjuaN6OG5MT0iHY2X/yE38gUj/05uUIMIRfpcwOdWnFQHBiXIhDojvAJQTEF1VOYFIETQMkeQ==
-  dependencies:
-    broccoli-file-creator "^1.1.1"
-    ember-cli-babel "^7.26.6"
-    ember-cli-htmlbars "^5.7.1"
-
 "ember-getowner-polyfill@^1.1.0 || ^2.0.0":
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/ember-getowner-polyfill/-/ember-getowner-polyfill-2.2.0.tgz#38e7dccbcac69d5ec694000329ec0b2be651d2b2"


### PR DESCRIPTION
It's advised to always use `resolveRegistration` for getting the config object if the owner is accessible from the code which it is in our case. `ember-get-config` uses `@embroider/macros` to resolve the config which can lead to unexpected content and duplicated config objects in the code instead of the meta tag.