### PR TITLE
fix(auth-route): store query params of attempted transition

### DIFF
--- a/addon/routes/oidc-authentication.js
+++ b/addon/routes/oidc-authentication.js
@@ -122,8 +122,7 @@ export default class OIDCAuthenticationRoute extends Route {
      * the login he can be sent to the initial destination.
      */
     if (!this.session.data.nextURL) {
-      const route = this.session.attemptedTransition?.to.name;
-      const url = route && this.router.urlFor(route);
+      const url = this.session.attemptedTransition?.intent?.url;
       this.session.set("data.nextURL", url);
     }
 

--- a/tests/unit/routes/oidc-authentication-test.js
+++ b/tests/unit/routes/oidc-authentication-test.js
@@ -188,7 +188,7 @@ module("Unit | Route | oidc-authentication", function (hooks) {
     });
   });
 
-  test("it stores an intercepted transition", function (assert) {
+  test("it stores an intercepted transition with query params", function (assert) {
     assert.expect(1);
 
     const router = this.owner.lookup("service:router");
@@ -200,13 +200,20 @@ module("Unit | Route | oidc-authentication", function (hooks) {
         redirectUri = "test";
         session = {
           data: { authenticated: {} },
-          attemptedTransition: { to: { name: "protected.users" } },
+          attemptedTransition: {
+            intent: {
+              url: "/protected/users?param0=value0&param1=value1",
+            },
+          },
           set(key, value) {
             set(this, key, value);
           },
         };
         _redirectToUrl() {
-          assert.strictEqual(this.session.data.nextURL, "/protected/users");
+          assert.strictEqual(
+            this.session.data.nextURL,
+            "/protected/users?param0=value0&param1=value1"
+          );
         }
       }
     );


### PR DESCRIPTION
Include the query parameters of the attempted transition
when storing the nextURL in the session storage. This ensures
that redirects after a successful login with the oidc provider
are performed correctly and don't result in 404 responses.