### PR TITLE
Fix 10 bugs in the OIDC authenticator (race conditions, multi-tab coordination)

### DIFF
--- a/addon/authenticators/oidc.js
+++ b/addon/authenticators/oidc.js
@@ -1,3 +1,4 @@
+import { debug } from "@ember/debug";
 import { cancel, later } from "@ember/runloop";
 import { service } from "@ember/service";
 import { waitForFetch } from "@ember/test-waiters";
@@ -155,7 +156,7 @@ export default class OidcAuthenticator extends BaseAuthenticator {
       return await this._refresh(refresh_token, redirectUri);
     }
 
-    this._scheduleRefresh(expireTime, refresh_token);
+    this._scheduleRefresh(expireTime, refresh_token, redirectUri);
     return sessionData;
   }
 
@@ -282,7 +283,7 @@ export default class OidcAuthenticator extends BaseAuthenticator {
     const expireTime =
       new Date().getTime() + expireInMilliseconds - this.config.refreshLeeway;
 
-    this._scheduleRefresh(expireTime, refresh_token);
+    this._scheduleRefresh(expireTime, refresh_token, redirectUri);
 
     return new TrackedObject({
       access_token,
@@ -299,8 +300,9 @@ export default class OidcAuthenticator extends BaseAuthenticator {
    *
    * @param {Number} expireTime Timestamp (ms) when the access token expires
    * @param {String} token The refresh token to use
+   * @param {String} redirectUri The redirect URI for the token endpoint
    */
-  _scheduleRefresh(expireTime, token) {
+  _scheduleRefresh(expireTime, token, redirectUri) {
     if (!expireTime || expireTime <= new Date().getTime()) {
       return;
     }
@@ -317,16 +319,14 @@ export default class OidcAuthenticator extends BaseAuthenticator {
       this,
       async (refreshToken) => {
         try {
-          const data = await this._refresh(refreshToken);
+          const data = await this._refresh(refreshToken, redirectUri);
           if (this._refreshGeneration !== generation || this.isDestroyed) {
             return;
           }
           this._upcomingRefresh = null;
           this.trigger("sessionDataUpdated", data);
-        } catch {
-          // Don't rethrow — the session will stay with the old token
-          // and the next API call will get a 401, triggering normal
-          // invalidation through the error-handling path.
+        } catch (e) {
+          debug(`Scheduled token refresh failed: ${e}`);
         }
       },
       token,

--- a/addon/authenticators/oidc.js
+++ b/addon/authenticators/oidc.js
@@ -13,6 +13,12 @@ import {
   isBadRequestResponse,
 } from "ember-simple-auth-oidc/utils/errors";
 
+// Random jitter added to the scheduled refresh delay so that multiple browser
+// tabs don't all fire their timer at the exact same millisecond.  Must be
+// strictly less than the configured refreshLeeway so the refresh always fires
+// before the actual token expiry.
+const REFRESH_JITTER_MAX_MS = 15000;
+
 export default class OidcAuthenticator extends BaseAuthenticator {
   @service router;
   @service session;
@@ -85,6 +91,10 @@ export default class OidcAuthenticator extends BaseAuthenticator {
       this._upcomingRefresh = null;
     }
     this._refreshGeneration = (this._refreshGeneration || 0) + 1;
+    // Clear in-flight dedup state so a stale resolved/rejected promise is
+    // never returned to a caller after the session has been invalidated.
+    this._inflightRefresh = null;
+    this._inflightRefreshToken = null;
     return resolve(true);
   }
 
@@ -167,6 +177,33 @@ export default class OidcAuthenticator extends BaseAuthenticator {
    * @returns {Object} The parsed response data
    */
   async _refresh(
+    refresh_token,
+    redirectUri,
+    retryCount = 0,
+    customParams = {},
+  ) {
+    // Deduplicate concurrent refresh calls within the same tab.  If a refresh
+    // is already in-flight for the same token, return the existing promise
+    // instead of firing a second request that would race at the OIDC provider.
+    if (this._inflightRefresh && this._inflightRefreshToken === refresh_token) {
+      return this._inflightRefresh;
+    }
+
+    this._inflightRefreshToken = refresh_token;
+    this._inflightRefresh = this.__doRefresh(
+      refresh_token,
+      redirectUri,
+      retryCount,
+      customParams,
+    ).finally(() => {
+      this._inflightRefresh = null;
+      this._inflightRefreshToken = null;
+    });
+
+    return this._inflightRefresh;
+  }
+
+  async __doRefresh(
     refresh_token,
     redirectUri,
     retryCount = 0,
@@ -302,6 +339,14 @@ export default class OidcAuthenticator extends BaseAuthenticator {
    * @param {String} token The refresh token to use
    * @param {String} redirectUri The redirect URI for the token endpoint
    */
+  /**
+   * Return a random jitter in [0, REFRESH_JITTER_MAX_MS) to spread scheduled
+   * refreshes across tabs.  Overridable in tests for determinism.
+   */
+  _refreshJitter() {
+    return Math.floor(Math.random() * REFRESH_JITTER_MAX_MS);
+  }
+
   _scheduleRefresh(expireTime, token, redirectUri) {
     if (!expireTime || expireTime <= new Date().getTime()) {
       return;
@@ -319,6 +364,28 @@ export default class OidcAuthenticator extends BaseAuthenticator {
       this,
       async (refreshToken) => {
         try {
+          // Multi-tab guard: before refreshing, check if another tab already
+          // refreshed the token.  All tabs share the session store (typically
+          // localStorage), so if the current session's refresh_token differs
+          // from the one captured in this closure, another tab won the race.
+          const currentRefreshToken =
+            this.session?.data?.authenticated?.refresh_token;
+          if (currentRefreshToken && currentRefreshToken !== refreshToken) {
+            debug(
+              "Scheduled refresh skipped — another tab already refreshed the token",
+            );
+            const currentExpireTime =
+              this.session?.data?.authenticated?.expireTime;
+            if (currentExpireTime && currentExpireTime > new Date().getTime()) {
+              this._scheduleRefresh(
+                currentExpireTime,
+                currentRefreshToken,
+                redirectUri,
+              );
+            }
+            return;
+          }
+
           const data = await this._refresh(refreshToken, redirectUri);
           if (this._refreshGeneration !== generation || this.isDestroyed) {
             return;
@@ -330,7 +397,7 @@ export default class OidcAuthenticator extends BaseAuthenticator {
         }
       },
       token,
-      expireTime - new Date().getTime(),
+      expireTime - new Date().getTime() + this._refreshJitter(),
     );
   }
 

--- a/addon/authenticators/oidc.js
+++ b/addon/authenticators/oidc.js
@@ -1,4 +1,4 @@
-import { later } from "@ember/runloop";
+import { cancel, later } from "@ember/runloop";
 import { service } from "@ember/service";
 import { waitForFetch } from "@ember/test-waiters";
 import BaseAuthenticator from "ember-simple-auth/authenticators/base";
@@ -79,6 +79,11 @@ export default class OidcAuthenticator extends BaseAuthenticator {
    * @return {Promise} The invalidate promise
    */
   invalidate() {
+    if (this._upcomingRefresh) {
+      cancel(this._upcomingRefresh);
+      this._upcomingRefresh = null;
+    }
+    this._refreshGeneration = (this._refreshGeneration || 0) + 1;
     return resolve(true);
   }
 
@@ -133,16 +138,24 @@ export default class OidcAuthenticator extends BaseAuthenticator {
    * @returns {Promise} A promise which resolves with the session data
    */
   async restore(sessionData) {
-    const { refresh_token, expireTime, redirectUri } = sessionData;
+    const { refresh_token, access_token, expireTime, redirectUri } =
+      sessionData;
 
     if (!refresh_token) {
       throw new Error("Refresh token is missing");
     }
 
-    if (expireTime && expireTime <= new Date().getTime()) {
+    // Stash refresh_token so _handleAuthResponse can recover it if the
+    // provider doesn't return one in the refresh response.
+    this._lastRefreshToken = refresh_token;
+
+    const needsRefresh =
+      !access_token || !expireTime || expireTime <= new Date().getTime();
+    if (needsRefresh) {
       return await this._refresh(refresh_token, redirectUri);
     }
 
+    this._scheduleRefresh(expireTime, refresh_token);
     return sessionData;
   }
 
@@ -248,6 +261,19 @@ export default class OidcAuthenticator extends BaseAuthenticator {
     id_token,
     redirectUri,
   }) {
+    // Some OIDC providers don't return refresh_token on refresh responses.
+    // Preserve the existing one to prevent session corruption.
+    if (!refresh_token) {
+      refresh_token = this._lastRefreshToken;
+    }
+    if (!refresh_token) {
+      throw new Error(
+        "refresh_token is missing from the token response and could not be " +
+          "recovered. The session will be unable to refresh on next restore.",
+      );
+    }
+    this._lastRefreshToken = refresh_token;
+
     const userinfo = await this._getUserinfo(access_token);
 
     const expireInMilliseconds = expires_in
@@ -255,6 +281,8 @@ export default class OidcAuthenticator extends BaseAuthenticator {
       : this.config.expiresIn;
     const expireTime =
       new Date().getTime() + expireInMilliseconds - this.config.refreshLeeway;
+
+    this._scheduleRefresh(expireTime, refresh_token);
 
     return new TrackedObject({
       access_token,
@@ -264,6 +292,46 @@ export default class OidcAuthenticator extends BaseAuthenticator {
       expireTime,
       redirectUri,
     });
+  }
+
+  /**
+   * Schedule a token refresh before the access token expires.
+   *
+   * @param {Number} expireTime Timestamp (ms) when the access token expires
+   * @param {String} token The refresh token to use
+   */
+  _scheduleRefresh(expireTime, token) {
+    if (!expireTime || expireTime <= new Date().getTime()) {
+      return;
+    }
+
+    if (this._upcomingRefresh) {
+      cancel(this._upcomingRefresh);
+      this._upcomingRefresh = null;
+    }
+
+    const generation = (this._refreshGeneration =
+      (this._refreshGeneration || 0) + 1);
+
+    this._upcomingRefresh = later(
+      this,
+      async (refreshToken) => {
+        try {
+          const data = await this._refresh(refreshToken);
+          if (this._refreshGeneration !== generation || this.isDestroyed) {
+            return;
+          }
+          this._upcomingRefresh = null;
+          this.trigger("sessionDataUpdated", data);
+        } catch {
+          // Don't rethrow — the session will stay with the old token
+          // and the next API call will get a 401, triggering normal
+          // invalidation through the error-handling path.
+        }
+      },
+      token,
+      expireTime - new Date().getTime(),
+    );
   }
 
   /**

--- a/addon/authenticators/oidc.js
+++ b/addon/authenticators/oidc.js
@@ -13,11 +13,7 @@ import {
   isBadRequestResponse,
 } from "ember-simple-auth-oidc/utils/errors";
 
-// Random jitter added to the scheduled refresh delay so that multiple browser
-// tabs don't all fire their timer at the exact same millisecond.  Must be
-// strictly less than the configured refreshLeeway so the refresh always fires
-// before the actual token expiry.
-const REFRESH_JITTER_MAX_MS = 15000;
+const REFRESH_JITTER_FALLBACK_MS = 15000;
 
 export default class OidcAuthenticator extends BaseAuthenticator {
   @service router;
@@ -333,20 +329,21 @@ export default class OidcAuthenticator extends BaseAuthenticator {
   }
 
   /**
+   * Return a random jitter in [0, maxJitter) to spread scheduled
+   * refreshes across tabs.  Overridable in tests for determinism.
+   */
+  _refreshJitter() {
+    const maxJitter = this.config.refreshLeeway || REFRESH_JITTER_FALLBACK_MS;
+    return Math.floor(Math.random() * maxJitter);
+  }
+
+  /**
    * Schedule a token refresh before the access token expires.
    *
    * @param {Number} expireTime Timestamp (ms) when the access token expires
    * @param {String} token The refresh token to use
    * @param {String} redirectUri The redirect URI for the token endpoint
    */
-  /**
-   * Return a random jitter in [0, REFRESH_JITTER_MAX_MS) to spread scheduled
-   * refreshes across tabs.  Overridable in tests for determinism.
-   */
-  _refreshJitter() {
-    return Math.floor(Math.random() * REFRESH_JITTER_MAX_MS);
-  }
-
   _scheduleRefresh(expireTime, token, redirectUri) {
     if (!expireTime || expireTime <= new Date().getTime()) {
       return;
@@ -384,9 +381,7 @@ export default class OidcAuthenticator extends BaseAuthenticator {
             (currentRefreshToken && currentRefreshToken !== refreshToken);
 
           if (anotherTabRefreshed) {
-            debug(
-              "Scheduled refresh skipped — another tab already refreshed",
-            );
+            debug("Scheduled refresh skipped — another tab already refreshed");
             if (currentExpireTime && currentExpireTime > new Date().getTime()) {
               this._scheduleRefresh(
                 currentExpireTime,

--- a/addon/authenticators/oidc.js
+++ b/addon/authenticators/oidc.js
@@ -360,26 +360,37 @@ export default class OidcAuthenticator extends BaseAuthenticator {
     const generation = (this._refreshGeneration =
       (this._refreshGeneration || 0) + 1);
 
+    // Capture the expireTime we used to schedule this timer.  When the
+    // callback fires we compare it against the session store's current
+    // expireTime — if they differ, another tab already refreshed.
+    // expireTime is the most reliable signal because it changes on every
+    // refresh regardless of whether the OIDC provider rotates refresh tokens.
+    const scheduledExpireTime = expireTime;
+
     this._upcomingRefresh = later(
       this,
       async (refreshToken) => {
         try {
-          // Multi-tab guard: before refreshing, check if another tab already
-          // refreshed the token.  All tabs share the session store (typically
-          // localStorage), so if the current session's refresh_token differs
-          // from the one captured in this closure, another tab won the race.
+          // Multi-tab guard: check if another tab already refreshed.
+          // We compare both expireTime (always changes) and refresh_token
+          // (changes with token rotation).  Either difference means
+          // another tab already refreshed — skip to avoid racing.
+          const currentExpireTime =
+            this.session?.data?.authenticated?.expireTime;
           const currentRefreshToken =
             this.session?.data?.authenticated?.refresh_token;
-          if (currentRefreshToken && currentRefreshToken !== refreshToken) {
+          const anotherTabRefreshed =
+            (currentExpireTime && currentExpireTime !== scheduledExpireTime) ||
+            (currentRefreshToken && currentRefreshToken !== refreshToken);
+
+          if (anotherTabRefreshed) {
             debug(
-              "Scheduled refresh skipped — another tab already refreshed the token",
+              "Scheduled refresh skipped — another tab already refreshed",
             );
-            const currentExpireTime =
-              this.session?.data?.authenticated?.expireTime;
             if (currentExpireTime && currentExpireTime > new Date().getTime()) {
               this._scheduleRefresh(
                 currentExpireTime,
-                currentRefreshToken,
+                currentRefreshToken || refreshToken,
                 redirectUri,
               );
             }

--- a/tests/unit/authenticators/oidc-test.js
+++ b/tests/unit/authenticators/oidc-test.js
@@ -445,8 +445,8 @@ module("Unit | Authenticator | OIDC", function (hooks) {
         sinon.stub(subject, "_scheduleRefresh");
 
         let fetchCount = 0;
-        const originalFetch = globalThis.fetch;
-        globalThis.fetch = async () => {
+        const originalFetch = window.fetch;
+        window.fetch = async () => {
           fetchCount++;
           return new Response(
             JSON.stringify({
@@ -478,7 +478,7 @@ module("Unit | Authenticator | OIDC", function (hooks) {
           assert.strictEqual(r1.access_token, "new-at");
           assert.strictEqual(r2.access_token, "new-at");
         } finally {
-          globalThis.fetch = originalFetch;
+          window.fetch = originalFetch;
         }
       });
 
@@ -487,8 +487,8 @@ module("Unit | Authenticator | OIDC", function (hooks) {
         sinon.stub(subject, "_scheduleRefresh");
 
         let fetchCount = 0;
-        const originalFetch = globalThis.fetch;
-        globalThis.fetch = async () => {
+        const originalFetch = window.fetch;
+        window.fetch = async () => {
           fetchCount++;
           return new Response(
             JSON.stringify({
@@ -517,7 +517,7 @@ module("Unit | Authenticator | OIDC", function (hooks) {
             "Two separate refresh cycles ran for different tokens",
           );
         } finally {
-          globalThis.fetch = originalFetch;
+          window.fetch = originalFetch;
         }
       });
 
@@ -526,8 +526,8 @@ module("Unit | Authenticator | OIDC", function (hooks) {
         sinon.stub(subject, "_scheduleRefresh");
 
         let fetchCount = 0;
-        const originalFetch = globalThis.fetch;
-        globalThis.fetch = async () => {
+        const originalFetch = window.fetch;
+        window.fetch = async () => {
           fetchCount++;
           return new Response(
             JSON.stringify({
@@ -559,7 +559,7 @@ module("Unit | Authenticator | OIDC", function (hooks) {
             "Second refresh: 2 more fetches (not deduped)",
           );
         } finally {
-          globalThis.fetch = originalFetch;
+          window.fetch = originalFetch;
         }
       });
 
@@ -567,8 +567,8 @@ module("Unit | Authenticator | OIDC", function (hooks) {
         const subject = this.owner.lookup("authenticator:oidc");
         sinon.stub(subject, "_scheduleRefresh");
 
-        const originalFetch = globalThis.fetch;
-        globalThis.fetch = async () => {
+        const originalFetch = window.fetch;
+        window.fetch = async () => {
           return new Response(JSON.stringify({ error: "invalid_grant" }), {
             status: 400,
             headers: { "Content-Type": "application/json" },
@@ -593,7 +593,7 @@ module("Unit | Authenticator | OIDC", function (hooks) {
             "Both callers received the rejection",
           );
         } finally {
-          globalThis.fetch = originalFetch;
+          window.fetch = originalFetch;
         }
       });
     });
@@ -622,12 +622,13 @@ module("Unit | Authenticator | OIDC", function (hooks) {
     });
 
     module("refresh jitter", function () {
-      test("_refreshJitter returns a value in [0, 15000)", function (assert) {
+      test("_refreshJitter returns a value in [0, refreshLeeway)", function (assert) {
         const subject = this.owner.lookup("authenticator:oidc");
+        const maxJitter = subject.config.refreshLeeway;
         for (let i = 0; i < 100; i++) {
           const jitter = subject._refreshJitter();
           assert.ok(jitter >= 0, `jitter ${jitter} >= 0`);
-          assert.ok(jitter < 15000, `jitter ${jitter} < 15000`);
+          assert.ok(jitter < maxJitter, `jitter ${jitter} < ${maxJitter}`);
         }
       });
 
@@ -639,11 +640,7 @@ module("Unit | Authenticator | OIDC", function (hooks) {
           return 0;
         };
 
-        subject._scheduleRefresh(
-          new Date().getTime() + 60000,
-          "token",
-          "test",
-        );
+        subject._scheduleRefresh(new Date().getTime() + 60000, "token", "test");
         assert.true(called, "_refreshJitter was invoked");
 
         // Clean up
@@ -681,11 +678,9 @@ module("Unit | Authenticator | OIDC", function (hooks) {
         // Simulate another tab updating the session
         const session = this.owner.lookup("service:session");
         const futureExpire = new Date().getTime() + 60000;
-        session.set("data", {
-          authenticated: {
-            refresh_token: "new-rt-from-other-tab",
-            expireTime: futureExpire,
-          },
+        set(session, "data.authenticated", {
+          refresh_token: "new-rt-from-other-tab",
+          expireTime: futureExpire,
         });
 
         // Wait for timer
@@ -720,11 +715,9 @@ module("Unit | Authenticator | OIDC", function (hooks) {
         // Session has the SAME token AND expireTime
         const scheduleTime = new Date().getTime() + 10;
         const session = this.owner.lookup("service:session");
-        session.set("data", {
-          authenticated: {
-            refresh_token: "same-rt",
-            expireTime: scheduleTime,
-          },
+        set(session, "data.authenticated", {
+          refresh_token: "same-rt",
+          expireTime: scheduleTime,
         });
 
         subject._scheduleRefresh(scheduleTime, "same-rt", "test");
@@ -759,22 +752,18 @@ module("Unit | Authenticator | OIDC", function (hooks) {
 
         const originalExpireTime = new Date().getTime() + 10;
         const session = this.owner.lookup("service:session");
-        session.set("data", {
-          authenticated: {
-            refresh_token: "non-rotating-rt",
-            expireTime: originalExpireTime,
-          },
+        set(session, "data.authenticated", {
+          refresh_token: "non-rotating-rt",
+          expireTime: originalExpireTime,
         });
 
         subject._scheduleRefresh(originalExpireTime, "non-rotating-rt", "test");
 
         // Another tab refreshed — same refresh_token but new expireTime
         const newExpireTime = new Date().getTime() + 60000;
-        session.set("data", {
-          authenticated: {
-            refresh_token: "non-rotating-rt",
-            expireTime: newExpireTime,
-          },
+        set(session, "data.authenticated", {
+          refresh_token: "non-rotating-rt",
+          expireTime: newExpireTime,
         });
 
         await new Promise((resolve) => setTimeout(resolve, 50));

--- a/tests/unit/authenticators/oidc-test.js
+++ b/tests/unit/authenticators/oidc-test.js
@@ -437,4 +437,300 @@ module("Unit | Authenticator | OIDC", function (hooks) {
       );
     });
   });
+
+  module("multi-tab coordination", function () {
+    module("_refresh deduplication", function () {
+      test("it deduplicates concurrent _refresh calls for the same token", async function (assert) {
+        const subject = this.owner.lookup("authenticator:oidc");
+        sinon.stub(subject, "_scheduleRefresh");
+
+        let fetchCount = 0;
+        const originalFetch = globalThis.fetch;
+        globalThis.fetch = async () => {
+          fetchCount++;
+          return new Response(
+            JSON.stringify({
+              access_token: "new-at",
+              refresh_token: "new-rt",
+              expires_in: 3600,
+              id_token: "id",
+            }),
+            {
+              status: 200,
+              headers: { "Content-Type": "application/json" },
+            },
+          );
+        };
+
+        try {
+          const p1 = subject._refresh("same-rt");
+          const p2 = subject._refresh("same-rt");
+
+          const [r1, r2] = await Promise.all([p1, p2]);
+
+          // Only one fetch should have been made
+          assert.strictEqual(
+            fetchCount,
+            // 2 fetches per _refresh: token POST + userinfo GET
+            2,
+            "Only one token refresh cycle ran (2 fetches: token + userinfo)",
+          );
+          assert.strictEqual(r1.access_token, "new-at");
+          assert.strictEqual(r2.access_token, "new-at");
+        } finally {
+          globalThis.fetch = originalFetch;
+        }
+      });
+
+      test("it does NOT deduplicate _refresh calls for different tokens", async function (assert) {
+        const subject = this.owner.lookup("authenticator:oidc");
+        sinon.stub(subject, "_scheduleRefresh");
+
+        let fetchCount = 0;
+        const originalFetch = globalThis.fetch;
+        globalThis.fetch = async () => {
+          fetchCount++;
+          return new Response(
+            JSON.stringify({
+              access_token: "new-at",
+              refresh_token: "new-rt",
+              expires_in: 3600,
+              id_token: "id",
+            }),
+            {
+              status: 200,
+              headers: { "Content-Type": "application/json" },
+            },
+          );
+        };
+
+        try {
+          await Promise.all([
+            subject._refresh("rt-A"),
+            subject._refresh("rt-B"),
+          ]);
+
+          // 2 fetches per _refresh call × 2 calls = 4
+          assert.strictEqual(
+            fetchCount,
+            4,
+            "Two separate refresh cycles ran for different tokens",
+          );
+        } finally {
+          globalThis.fetch = originalFetch;
+        }
+      });
+
+      test("dedup clears after completion — subsequent call makes a new request", async function (assert) {
+        const subject = this.owner.lookup("authenticator:oidc");
+        sinon.stub(subject, "_scheduleRefresh");
+
+        let fetchCount = 0;
+        const originalFetch = globalThis.fetch;
+        globalThis.fetch = async () => {
+          fetchCount++;
+          return new Response(
+            JSON.stringify({
+              access_token: "new-at",
+              refresh_token: "new-rt",
+              expires_in: 3600,
+              id_token: "id",
+            }),
+            {
+              status: 200,
+              headers: { "Content-Type": "application/json" },
+            },
+          );
+        };
+
+        try {
+          await subject._refresh("rt-1");
+          assert.strictEqual(fetchCount, 2, "First refresh: 2 fetches");
+          assert.strictEqual(
+            subject._inflightRefresh,
+            null,
+            "In-flight state cleared after first refresh",
+          );
+
+          await subject._refresh("rt-1");
+          assert.strictEqual(
+            fetchCount,
+            4,
+            "Second refresh: 2 more fetches (not deduped)",
+          );
+        } finally {
+          globalThis.fetch = originalFetch;
+        }
+      });
+
+      test("dedup propagates failure to both callers", async function (assert) {
+        const subject = this.owner.lookup("authenticator:oidc");
+        sinon.stub(subject, "_scheduleRefresh");
+
+        const originalFetch = globalThis.fetch;
+        globalThis.fetch = async () => {
+          return new Response(JSON.stringify({ error: "invalid_grant" }), {
+            status: 400,
+            headers: { "Content-Type": "application/json" },
+          });
+        };
+
+        try {
+          const errors = [];
+
+          const p1 = subject._refresh("same-rt").catch((e) => {
+            errors.push(e);
+          });
+          const p2 = subject._refresh("same-rt").catch((e) => {
+            errors.push(e);
+          });
+
+          await Promise.all([p1, p2]);
+
+          assert.strictEqual(
+            errors.length,
+            2,
+            "Both callers received the rejection",
+          );
+        } finally {
+          globalThis.fetch = originalFetch;
+        }
+      });
+    });
+
+    module("invalidate clears dedup state", function () {
+      test("it clears _inflightRefresh and _inflightRefreshToken", async function (assert) {
+        const subject = this.owner.lookup("authenticator:oidc");
+
+        // Simulate in-flight state
+        subject._inflightRefresh = Promise.resolve();
+        subject._inflightRefreshToken = "rt";
+
+        await subject.invalidate();
+
+        assert.strictEqual(
+          subject._inflightRefresh,
+          null,
+          "_inflightRefresh cleared",
+        );
+        assert.strictEqual(
+          subject._inflightRefreshToken,
+          null,
+          "_inflightRefreshToken cleared",
+        );
+      });
+    });
+
+    module("refresh jitter", function () {
+      test("_refreshJitter returns a value in [0, 15000)", function (assert) {
+        const subject = this.owner.lookup("authenticator:oidc");
+        for (let i = 0; i < 100; i++) {
+          const jitter = subject._refreshJitter();
+          assert.ok(jitter >= 0, `jitter ${jitter} >= 0`);
+          assert.ok(jitter < 15000, `jitter ${jitter} < 15000`);
+        }
+      });
+
+      test("_refreshJitter is called when scheduling", function (assert) {
+        const subject = this.owner.lookup("authenticator:oidc");
+        let called = false;
+        subject._refreshJitter = () => {
+          called = true;
+          return 0;
+        };
+
+        subject._scheduleRefresh(
+          new Date().getTime() + 60000,
+          "token",
+          "test",
+        );
+        assert.true(called, "_refreshJitter was invoked");
+
+        // Clean up
+        cancel(subject._upcomingRefresh);
+        subject._upcomingRefresh = null;
+      });
+    });
+
+    module("multi-tab guard in _scheduleRefresh callback", function () {
+      test("it skips refresh when session token was updated by another tab", async function (assert) {
+        const subject = this.owner.lookup("authenticator:oidc");
+        subject._refreshJitter = () => 0;
+
+        let refreshCalled = false;
+        sinon.stub(subject, "_refresh").callsFake(() => {
+          refreshCalled = true;
+          return Promise.resolve({});
+        });
+
+        // Track re-schedule calls
+        const reScheduleCalls = [];
+        const originalSchedule = subject._scheduleRefresh.bind(subject);
+        let callCount = 0;
+        subject._scheduleRefresh = function (expireTime, token, rUri) {
+          callCount++;
+          if (callCount === 1) {
+            return originalSchedule(expireTime, token, rUri);
+          }
+          reScheduleCalls.push({ expireTime, token });
+        };
+
+        // Schedule with 'old-rt' — fires in ~10ms
+        subject._scheduleRefresh(new Date().getTime() + 10, "old-rt", "test");
+
+        // Simulate another tab updating the session
+        const session = this.owner.lookup("service:session");
+        const futureExpire = new Date().getTime() + 60000;
+        session.set("data", {
+          authenticated: {
+            refresh_token: "new-rt-from-other-tab",
+            expireTime: futureExpire,
+          },
+        });
+
+        // Wait for timer
+        await new Promise((resolve) => setTimeout(resolve, 50));
+
+        assert.false(refreshCalled, "_refresh was NOT called");
+        assert.strictEqual(reScheduleCalls.length, 1, "Re-scheduled once");
+        assert.strictEqual(
+          reScheduleCalls[0].token,
+          "new-rt-from-other-tab",
+          "Re-scheduled with the new token",
+        );
+
+        // Clean up
+        subject.invalidate();
+      });
+
+      test("it proceeds when session token matches (no other tab refreshed)", async function (assert) {
+        const subject = this.owner.lookup("authenticator:oidc");
+        subject._refreshJitter = () => 0;
+
+        let refreshCalledWith = null;
+        sinon.stub(subject, "_refresh").callsFake((token) => {
+          refreshCalledWith = token;
+          return Promise.resolve({
+            access_token: "at",
+            refresh_token: "rt",
+            expireTime: new Date().getTime() + 60000,
+          });
+        });
+
+        // Session has the SAME token
+        const session = this.owner.lookup("service:session");
+        session.set("data", {
+          authenticated: { refresh_token: "same-rt" },
+        });
+
+        subject._scheduleRefresh(new Date().getTime() + 10, "same-rt", "test");
+
+        await new Promise((resolve) => setTimeout(resolve, 50));
+
+        assert.strictEqual(refreshCalledWith, "same-rt", "_refresh was called");
+
+        subject.invalidate();
+      });
+    });
+  });
 });

--- a/tests/unit/authenticators/oidc-test.js
+++ b/tests/unit/authenticators/oidc-test.js
@@ -703,7 +703,7 @@ module("Unit | Authenticator | OIDC", function (hooks) {
         subject.invalidate();
       });
 
-      test("it proceeds when session token matches (no other tab refreshed)", async function (assert) {
+      test("it proceeds when session data matches (no other tab refreshed)", async function (assert) {
         const subject = this.owner.lookup("authenticator:oidc");
         subject._refreshJitter = () => 0;
 
@@ -717,17 +717,78 @@ module("Unit | Authenticator | OIDC", function (hooks) {
           });
         });
 
-        // Session has the SAME token
+        // Session has the SAME token AND expireTime
+        const scheduleTime = new Date().getTime() + 10;
         const session = this.owner.lookup("service:session");
         session.set("data", {
-          authenticated: { refresh_token: "same-rt" },
+          authenticated: {
+            refresh_token: "same-rt",
+            expireTime: scheduleTime,
+          },
         });
 
-        subject._scheduleRefresh(new Date().getTime() + 10, "same-rt", "test");
+        subject._scheduleRefresh(scheduleTime, "same-rt", "test");
 
         await new Promise((resolve) => setTimeout(resolve, 50));
 
         assert.strictEqual(refreshCalledWith, "same-rt", "_refresh was called");
+
+        subject.invalidate();
+      });
+
+      test("it skips refresh when refresh_token is same but expireTime changed (no token rotation)", async function (assert) {
+        const subject = this.owner.lookup("authenticator:oidc");
+        subject._refreshJitter = () => 0;
+
+        let refreshCalled = false;
+        sinon.stub(subject, "_refresh").callsFake(() => {
+          refreshCalled = true;
+          return Promise.resolve({});
+        });
+
+        const reScheduleCalls = [];
+        const originalSchedule = subject._scheduleRefresh.bind(subject);
+        let callCount = 0;
+        subject._scheduleRefresh = function (expireTime, token, rUri) {
+          callCount++;
+          if (callCount === 1) {
+            return originalSchedule(expireTime, token, rUri);
+          }
+          reScheduleCalls.push({ expireTime, token });
+        };
+
+        const originalExpireTime = new Date().getTime() + 10;
+        const session = this.owner.lookup("service:session");
+        session.set("data", {
+          authenticated: {
+            refresh_token: "non-rotating-rt",
+            expireTime: originalExpireTime,
+          },
+        });
+
+        subject._scheduleRefresh(originalExpireTime, "non-rotating-rt", "test");
+
+        // Another tab refreshed — same refresh_token but new expireTime
+        const newExpireTime = new Date().getTime() + 60000;
+        session.set("data", {
+          authenticated: {
+            refresh_token: "non-rotating-rt",
+            expireTime: newExpireTime,
+          },
+        });
+
+        await new Promise((resolve) => setTimeout(resolve, 50));
+
+        assert.false(
+          refreshCalled,
+          "_refresh was NOT called — guard detected expireTime change",
+        );
+        assert.strictEqual(reScheduleCalls.length, 1, "Re-scheduled once");
+        assert.strictEqual(
+          reScheduleCalls[0].expireTime,
+          newExpireTime,
+          "Re-scheduled with the new expireTime",
+        );
 
         subject.invalidate();
       });

--- a/tests/unit/authenticators/oidc-test.js
+++ b/tests/unit/authenticators/oidc-test.js
@@ -1,7 +1,9 @@
 import { set } from "@ember/object";
+import { cancel } from "@ember/runloop";
 import setupMirage from "ember-cli-mirage/test-support/setup-mirage";
 import { setupTest } from "ember-qunit";
 import { module, test } from "qunit";
+import sinon from "sinon";
 
 const getTokenBody = (expired) => {
   const time = expired ? -30 : 120;
@@ -119,5 +121,320 @@ module("Unit | Authenticator | OIDC", function (hooks) {
       bodyWithoutRefresh,
       "redirect_uri=test%2Fredirect&client_id=test-client&grant_type=authorization_code&foo=bar&code=test-code",
     );
+  });
+
+  module("_scheduleRefresh error handling", function () {
+    test("it does nothing when expireTime is falsy (0)", function (assert) {
+      const subject = this.owner.lookup("authenticator:oidc");
+      subject._scheduleRefresh(0, "token");
+      assert.strictEqual(
+        subject._upcomingRefresh,
+        undefined,
+        "No refresh is scheduled when expireTime is 0",
+      );
+    });
+
+    test("it does nothing when expireTime is null", function (assert) {
+      const subject = this.owner.lookup("authenticator:oidc");
+      subject._scheduleRefresh(null, "token");
+      assert.strictEqual(
+        subject._upcomingRefresh,
+        undefined,
+        "No refresh is scheduled when expireTime is null",
+      );
+    });
+
+    test("it does nothing when expireTime is undefined (NaN guard)", function (assert) {
+      const subject = this.owner.lookup("authenticator:oidc");
+      subject._scheduleRefresh(undefined, "token");
+      assert.strictEqual(
+        subject._upcomingRefresh,
+        undefined,
+        "No refresh is scheduled when expireTime is undefined",
+      );
+    });
+
+    test("it does nothing when expireTime is in the past", function (assert) {
+      const subject = this.owner.lookup("authenticator:oidc");
+      const pastTime = new Date().getTime() - 10000;
+      subject._scheduleRefresh(pastTime, "token");
+      assert.strictEqual(
+        subject._upcomingRefresh,
+        undefined,
+        "No refresh is scheduled when expireTime is in the past",
+      );
+    });
+
+    test("it schedules a refresh when expireTime is in the future", function (assert) {
+      const subject = this.owner.lookup("authenticator:oidc");
+      const futureTime = new Date().getTime() + 60000;
+      subject._scheduleRefresh(futureTime, "token");
+      assert.notStrictEqual(
+        subject._upcomingRefresh,
+        undefined,
+        "A refresh is scheduled when expireTime is in the future",
+      );
+      // Clean up the scheduled timer
+      cancel(subject._upcomingRefresh);
+      subject._upcomingRefresh = null;
+    });
+  });
+
+  module("_scheduleRefresh generation counter", function () {
+    test("it bumps the generation counter on each call", function (assert) {
+      const subject = this.owner.lookup("authenticator:oidc");
+      const futureTime = new Date().getTime() + 60000;
+
+      subject._scheduleRefresh(futureTime, "token");
+      const gen1 = subject._refreshGeneration;
+
+      subject._scheduleRefresh(futureTime, "token");
+      const gen2 = subject._refreshGeneration;
+
+      assert.ok(gen2 > gen1, "Generation counter is bumped on each call");
+
+      // Clean up
+      cancel(subject._upcomingRefresh);
+      subject._upcomingRefresh = null;
+    });
+
+    test("it cancels the previous timer when scheduling a new one", function (assert) {
+      const subject = this.owner.lookup("authenticator:oidc");
+      const futureTime = new Date().getTime() + 60000;
+
+      subject._scheduleRefresh(futureTime, "token");
+      const firstTimer = subject._upcomingRefresh;
+      assert.ok(firstTimer, "First timer is scheduled");
+
+      subject._scheduleRefresh(futureTime, "token");
+      const secondTimer = subject._upcomingRefresh;
+      assert.ok(secondTimer, "Second timer is scheduled");
+      assert.notEqual(
+        firstTimer,
+        secondTimer,
+        "A new timer replaced the old one",
+      );
+
+      // Clean up
+      cancel(subject._upcomingRefresh);
+      subject._upcomingRefresh = null;
+    });
+  });
+
+  module("invalidate cancels refresh", function () {
+    test("it cancels a pending scheduled refresh", async function (assert) {
+      const subject = this.owner.lookup("authenticator:oidc");
+      // Stub _refresh to prevent network requests from the scheduled timer
+      sinon.stub(subject, "_refresh").resolves({});
+
+      // Manually set a truthy _upcomingRefresh so invalidate's guard fires
+      subject._upcomingRefresh = 42;
+
+      await subject.invalidate();
+      assert.strictEqual(
+        subject._upcomingRefresh,
+        null,
+        "Pending refresh is cancelled (set to null) after invalidate",
+      );
+    });
+
+    test("it bumps _refreshGeneration so stale callbacks are discarded", async function (assert) {
+      const subject = this.owner.lookup("authenticator:oidc");
+
+      // Set a known generation value
+      subject._refreshGeneration = 5;
+
+      await subject.invalidate();
+      assert.strictEqual(
+        subject._refreshGeneration,
+        6,
+        "Generation counter is bumped after invalidate",
+      );
+    });
+  });
+
+  module("_handleAuthResponse preserves refresh_token", function () {
+    test("it uses _lastRefreshToken when response has no refresh_token", async function (assert) {
+      const subject = this.owner.lookup("authenticator:oidc");
+      subject._lastRefreshToken = "stashed-refresh-token";
+
+      // Stub _scheduleRefresh to avoid side effects
+      sinon.stub(subject, "_scheduleRefresh");
+
+      const result = await subject._handleAuthResponse({
+        access_token: "new-access",
+        refresh_token: undefined,
+        expires_in: 300,
+        id_token: "id",
+        redirectUri: "test",
+      });
+
+      assert.strictEqual(
+        result.refresh_token,
+        "stashed-refresh-token",
+        "Falls back to _lastRefreshToken",
+      );
+    });
+
+    test("it uses response refresh_token and updates _lastRefreshToken", async function (assert) {
+      const subject = this.owner.lookup("authenticator:oidc");
+      subject._lastRefreshToken = "old-refresh-token";
+
+      sinon.stub(subject, "_scheduleRefresh");
+
+      const result = await subject._handleAuthResponse({
+        access_token: "new-access",
+        refresh_token: "new-refresh-token",
+        expires_in: 300,
+        id_token: "id",
+        redirectUri: "test",
+      });
+
+      assert.strictEqual(
+        result.refresh_token,
+        "new-refresh-token",
+        "Uses the refresh_token from the response",
+      );
+      assert.strictEqual(
+        subject._lastRefreshToken,
+        "new-refresh-token",
+        "_lastRefreshToken is updated to the new value",
+      );
+    });
+
+    test("it throws when both response and _lastRefreshToken are empty", async function (assert) {
+      const subject = this.owner.lookup("authenticator:oidc");
+      subject._lastRefreshToken = undefined;
+
+      sinon.stub(subject, "_scheduleRefresh");
+
+      await assert.rejects(
+        subject._handleAuthResponse({
+          access_token: "new-access",
+          refresh_token: undefined,
+          expires_in: 300,
+          id_token: "id",
+          redirectUri: "test",
+        }),
+        /refresh_token is missing/,
+        "Throws when no refresh_token is available",
+      );
+    });
+  });
+
+  module("restore refresh conditions", function () {
+    test("it refreshes when access_token is missing", async function (assert) {
+      const subject = this.owner.lookup("authenticator:oidc");
+      const refreshStub = sinon
+        .stub(subject, "_refresh")
+        .resolves({ access_token: "new", refresh_token: "rt" });
+
+      await subject.restore({
+        refresh_token: "rt",
+        expireTime: new Date().getTime() + 60000,
+        redirectUri: "test",
+      });
+
+      assert.ok(
+        refreshStub.calledOnce,
+        "_refresh is called when access_token is missing",
+      );
+    });
+
+    test("it refreshes when expireTime is undefined", async function (assert) {
+      const subject = this.owner.lookup("authenticator:oidc");
+      const refreshStub = sinon
+        .stub(subject, "_refresh")
+        .resolves({ access_token: "new", refresh_token: "rt" });
+
+      await subject.restore({
+        refresh_token: "rt",
+        access_token: "at",
+        expireTime: undefined,
+        redirectUri: "test",
+      });
+
+      assert.ok(
+        refreshStub.calledOnce,
+        "_refresh is called when expireTime is undefined",
+      );
+    });
+
+    test("it refreshes when expireTime is in the past", async function (assert) {
+      const subject = this.owner.lookup("authenticator:oidc");
+      const refreshStub = sinon
+        .stub(subject, "_refresh")
+        .resolves({ access_token: "new", refresh_token: "rt" });
+
+      await subject.restore({
+        refresh_token: "rt",
+        access_token: "at",
+        expireTime: new Date().getTime() - 10000,
+        redirectUri: "test",
+      });
+
+      assert.ok(
+        refreshStub.calledOnce,
+        "_refresh is called when expireTime is in the past",
+      );
+    });
+
+    test("it returns sessionData when token is still valid", async function (assert) {
+      const subject = this.owner.lookup("authenticator:oidc");
+      const futureTime = new Date().getTime() + 60000;
+      const sessionData = {
+        refresh_token: "rt",
+        access_token: "at",
+        expireTime: futureTime,
+        redirectUri: "test",
+      };
+
+      // Stub _scheduleRefresh to avoid side effects
+      sinon.stub(subject, "_scheduleRefresh");
+
+      const result = await subject.restore(sessionData);
+
+      assert.strictEqual(
+        result,
+        sessionData,
+        "Returns the original session data when token is still valid",
+      );
+    });
+
+    test("it stashes refresh_token in _lastRefreshToken before calling _refresh", async function (assert) {
+      const subject = this.owner.lookup("authenticator:oidc");
+
+      let capturedLastRefreshToken;
+      sinon.stub(subject, "_refresh").callsFake(function () {
+        capturedLastRefreshToken = subject._lastRefreshToken;
+        return Promise.resolve({ access_token: "new", refresh_token: "rt" });
+      });
+
+      await subject.restore({
+        refresh_token: "my-refresh-token",
+        expireTime: new Date().getTime() - 10000,
+        redirectUri: "test",
+      });
+
+      assert.strictEqual(
+        capturedLastRefreshToken,
+        "my-refresh-token",
+        "_lastRefreshToken is set before _refresh is called",
+      );
+    });
+
+    test("it throws when refresh_token is missing", async function (assert) {
+      const subject = this.owner.lookup("authenticator:oidc");
+
+      await assert.rejects(
+        subject.restore({
+          access_token: "at",
+          expireTime: new Date().getTime() + 60000,
+          redirectUri: "test",
+        }),
+        /Refresh token is missing/,
+        "Throws when refresh_token is missing from session data",
+      );
+    });
   });
 });


### PR DESCRIPTION
## Summary

This PR fixes 10 bugs in the OIDC authenticator (`addon/authenticators/oidc.js`) related to race conditions, unhandled rejections, missing token handling, and multi-tab coordination. All fixes are backwards-compatible.

## Fixes

### Core fixes (original)

1. **Unhandled promise rejection in scheduled refresh** — `_scheduleRefresh()` now wraps the `_refresh()` call in try/catch. Previously, if the refresh failed inside a `later()` callback, the rejection was unhandled.

2. **NaN/undefined `expireTime` guard** — `_scheduleRefresh()` now returns early when `expireTime` is falsy, preventing `later()` from being called with an invalid delay.

3. **Cancel pending refresh on `invalidate()`** — `invalidate()` now cancels any pending `later()` timer. Previously, logging out while a refresh was scheduled could cause `sessionDataUpdated` to fire after the session was already invalidated.

4. **Generation counter prevents stale refresh callbacks** — `_scheduleRefresh()` now uses a generation counter so that if multiple refreshes are scheduled in quick succession, only the most recent one triggers `sessionDataUpdated`.

5. **Preserve `refresh_token` when server omits it** — `_handleAuthResponse()` now falls back to the last known `refresh_token` when the token response doesn't include one. Some OIDC providers don't return a `refresh_token` on refresh grant responses. Relates to #1127.

6. **`restore()` handles missing `access_token` and `undefined` `expireTime`** — Previously, `restore()` only refreshed when `expireTime` was set *and* expired. Now it also refreshes when `access_token` is missing or `expireTime` is undefined.

### Multi-tab coordination (new)

7. **Refresh jitter (0–15s)** — Adds a random delay to the scheduled refresh timer via `_refreshJitter()`. This prevents multiple browser tabs from all firing their refresh at the exact same millisecond, reducing the chance of concurrent token rotation races.

8. **Same-tab dedup in `_refresh()`** — If `_refresh` is already in-flight for the same token, returns the existing promise instead of firing a duplicate request. Prevents the OIDC provider from seeing two concurrent requests with the same refresh token, which causes failures with token rotation.

9. **Multi-tab guard in `_scheduleRefresh` callback** — Before refreshing, checks if the session store's `refresh_token` differs from the closure-captured one (meaning another tab already refreshed). Skips the refresh and re-schedules with the updated token.

10. **`invalidate()` clears dedup state** — Clears `_inflightRefresh` and `_inflightRefreshToken` during invalidation so stale promises are never returned after session invalidation.

## Backwards Compatibility

All changes are additive. No public API changes, no new configuration options, and no changes to the session data shape. `_refreshJitter()` is a new method that can be overridden in subclasses for testing or custom jitter strategies.

## Test Plan

- [x] Added unit tests for `_scheduleRefresh` error handling (NaN, null, past expireTime)
- [x] Added unit tests for generation counter (bumps, cancels previous timer)
- [x] Added unit tests for `invalidate` cancelling refresh and clearing dedup state
- [x] Added unit tests for `_handleAuthResponse` refresh_token preservation
- [x] Added unit tests for `restore()` refresh conditions
- [x] Added unit tests for `_refresh` deduplication (same token, different tokens, failure propagation)
- [x] Added unit tests for `_refreshJitter` range
- [x] Added integration tests for multi-tab guard (real timer callback with session mutation)
- [ ] Verify existing test suite still passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)